### PR TITLE
Issue 93 tagging enhancements

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -1,9 +1,9 @@
 import { createElement, getArticleRelatedMetadata } from '../../scripts/utils.js';
 
-function decorateArticlePageHero(block) {
+async function decorateArticlePageHero(block) {
   const {
     readTime, author, primaryTopic, date,
-  } = getArticleRelatedMetadata();
+  } = await getArticleRelatedMetadata();
   const h1 = block.querySelector('h1');
   const readIcon = createElement('img', {
     src: '/icons/list.svg',

--- a/scripts/ffetch.js
+++ b/scripts/ffetch.js
@@ -19,7 +19,8 @@ async function* request(url, context) {
   for (let offset = 0, total = Infinity; offset < total; offset += chunkSize) {
     const params = new URLSearchParams(`offset=${offset}&limit=${chunkSize}`);
     if (sheetName) params.append('sheet', sheetName);
-    const resp = await fetch(`${url}?${params.toString()}`, { cache: cacheReload ? 'reload' : 'default' });
+    const separator = url.includes('?') ? '&' : '?';
+    const resp = await fetch(`${url}${separator}${params.toString()}`, { cache: cacheReload ? 'reload' : 'default' });
     if (resp.ok) {
       const json = await resp.json();
       total = json.total;

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -1,13 +1,15 @@
 import ffetch from './ffetch.js';
 
-const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';
-let taxonomyPromise;
-function fetchTaxonomy() {
-  if (!taxonomyPromise) {
-    taxonomyPromise = new Promise((resolve, reject) => {
+const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json';
+const taxonomyPromises = {};
+
+function fetchTaxonomy(sheet) {
+  if (!taxonomyPromises[sheet]) {
+    taxonomyPromises[sheet] = new Promise((resolve, reject) => {
       (async () => {
         try {
-          const taxonomyJson = await ffetch(taxonomyEndpoint).all();
+          const sheetParameter = sheet ? `?sheet=${sheet}` : '';
+          const taxonomyJson = await ffetch(`${taxonomyEndpoint}${sheetParameter}`).all();
           const taxonomy = {};
 
           taxonomyJson.forEach((row) => {
@@ -25,7 +27,9 @@ function fetchTaxonomy() {
                 };
               }
               if (index === levels.length - 1) {
-                currentLevel[tag].title = row.en;
+                if (row.en) {
+                  currentLevel[tag].title = row.en;
+                }
               } else {
                 currentLevel = currentLevel[tag];
               }
@@ -38,7 +42,7 @@ function fetchTaxonomy() {
       })();
     });
   }
-  return taxonomyPromise;
+  return taxonomyPromises[sheet];
 }
 
 const getDeepNestedObject = (obj, filter) => Object.entries(obj)
@@ -58,8 +62,8 @@ const getDeepNestedObject = (obj, filter) => Object.entries(obj)
  * Get the taxonomy a a hierarchical json object
  * @returns {Promise} the taxonomy
  */
-export function getTaxonomy() {
-  return fetchTaxonomy();
+export function getTaxonomy(sheet) {
+  return fetchTaxonomy(sheet);
 }
 
 /**

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -1,6 +1,6 @@
 import ffetch from './ffetch.js';
 
-const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';//'/config/sidekick/taxonomy-nestor.json?sheet=tags';
+const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';
 let taxonomyPromise;
 function fetchTaxonomy() {
   if (!taxonomyPromise) {

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -1,10 +1,6 @@
 import ffetch from './ffetch.js';
 
-function titleToName(name) {
-  return name.toLowerCase().replace(' ', '-');
-}
-
-const taxonomyEndpoint = '/config/sidekick/taxonomy.json';
+const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';//'/config/sidekick/taxonomy-nestor.json?sheet=tags';
 let taxonomyPromise;
 function fetchTaxonomy() {
   if (!taxonomyPromise) {
@@ -13,73 +9,27 @@ function fetchTaxonomy() {
         try {
           const taxonomyJson = await ffetch(taxonomyEndpoint).all();
           const taxonomy = {};
-          let currentType;
-          let currentL1; let currentL2; let
-            currentL3;
 
           taxonomyJson.forEach((row) => {
-            // Handle Type level
-            if (row.Type) {
-              currentType = row.Type;
-              taxonomy[currentType] = {
-                title: currentType,
-                name: titleToName(currentType),
-                path: titleToName(currentType),
-                hide: row.hide,
-              };
-            }
-
-            // Handle Level 1
-            if (row['Level 1'] && currentType) {
-              currentL1 = row['Level 1'];
-              if (!taxonomy[currentType][currentL1]) {
-                taxonomy[currentType][currentL1] = {
-                  title: currentL1,
-                  name: titleToName(currentL1),
-                  path: `${titleToName(currentType)}/${titleToName(currentL1)}`,
-                  hide: row.hide,
+            const levels = row.tag.split('/');
+            let currentLevel = taxonomy;
+            let currentPath = '';
+            levels.forEach((tag, index) => {
+              currentPath = currentPath ? `${currentPath}/${tag}` : tag;
+              if (!currentLevel[tag]) {
+                currentLevel[tag] = {
+                  title: tag,
+                  name: tag,
+                  path: currentPath,
+                  hide: false,
                 };
               }
-            }
-
-            // Handle Level 2
-            if (row['Level 2'] && currentType && currentL1) {
-              currentL2 = row['Level 2'];
-              if (!taxonomy[currentType][currentL1][currentL2]) {
-                taxonomy[currentType][currentL1][currentL2] = {
-                  title: currentL2,
-                  name: titleToName(currentL2),
-                  path: `${titleToName(currentType)}/${titleToName(currentL1)}/${titleToName(currentL2)}`,
-                  hide: row.hide,
-                };
+              if (index === levels.length - 1) {
+                currentLevel[tag].title = row.en;
+              } else {
+                currentLevel = currentLevel[tag];
               }
-            }
-
-            // Handle Level 3
-            if (row['Level 3'] && currentType && currentL1 && currentL2) {
-              currentL3 = row['Level 3'];
-              if (currentL3 && !taxonomy[currentType][currentL1][currentL2][currentL3]) {
-                taxonomy[currentType][currentL1][currentL2][currentL3] = {
-                  title: currentL3,
-                  name: titleToName(currentL3),
-                  path: `${titleToName(currentType)}/${titleToName(currentL1)}/${titleToName(currentL2)}/${titleToName(currentL3)}`,
-                  hide: row.hide,
-                };
-              }
-            }
-
-            // Handle Level 4
-            if (row['Level 4'] && currentType && currentL1 && currentL2 && currentL3) {
-              const currentL4 = row['Level 4'];
-              if (currentL4) {
-                taxonomy[currentType][currentL1][currentL2][currentL3][currentL4] = {
-                  title: currentL4,
-                  name: titleToName(currentL4),
-                  path: `${titleToName(currentType)}/${titleToName(currentL1)}/${titleToName(currentL2)}/${titleToName(currentL3)}/${titleToName(currentL4)}`,
-                  hide: row.hide,
-                };
-              }
-            }
+            });
           });
           resolve(taxonomy);
         } catch (e) {

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -1,6 +1,6 @@
 import ffetch from './ffetch.js';
 
-const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json';
+const taxonomyEndpoint = '/config/sidekick/taxonomy.json';
 const taxonomyPromises = {};
 
 function fetchTaxonomy(sheet) {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,5 +1,48 @@
 /* eslint-disable import/prefer-default-export */
 import { getMetadata } from './aem.js';
+import ffetch from './ffetch.js';
+
+/**
+ * Language
+ */
+function getCurrentLang() {
+  return 'en'; //TODO: Add logic
+}
+
+function getDefaultLang() {
+  return 'en';
+}
+
+/**
+ * Taxonomy
+ */
+const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';
+let taxonomyPromise = null;
+
+function fetchTaxonomy(sheet) {
+  if (!taxonomyPromise) {
+    taxonomyPromise = new Promise((resolve, reject) => {
+      (async () => {
+        try {
+          const taxonomyJson = await ffetch(`${taxonomyEndpoint}`).all();
+          const taxonomy = {};
+          const currentLang = getCurrentLang();
+          const defaultLang = getDefaultLang();
+          taxonomyJson.forEach((row) => {
+            taxonomy[row.tag] = {
+              tag: row.tag,
+              title: row[currentLang] && row[defaultLang],
+            }
+          });
+          resolve(taxonomy);
+        } catch (e) {
+          reject(e);
+        }
+      })();
+    });
+  }
+  return taxonomyPromise;
+}
 
 /**
  * Creates a new HTML element
@@ -24,6 +67,20 @@ function createElement(tagName, attributes, ...children) {
 }
 
 /**
+ * Returns the tag information from a tagname
+ * 
+ * @param {string} tagName 
+ * @returns {Promise} Object containing tag data or empty object if not exists
+ * @property {string} title - The tag title
+ * @property {string} tag - Tag path
+ */
+function getTag(tagFullName) {
+  return fetchTaxonomy().then((taxonomy) => {
+    return taxonomy[tagFullName];
+  });
+}
+
+/**
  * Retrieves article-related metadata from the page
  * @returns {Object} Object containing article metadata
  * @property {string} template - The template type
@@ -32,18 +89,20 @@ function createElement(tagName, attributes, ...children) {
  * @property {string} tag - Article tag
  * @property {string} date - Article publication date
  */
-function getArticleRelatedMetadata() {
+async function getArticleRelatedMetadata() {
   const template = getMetadata('template');
   const readTime = getMetadata('read-time');
   const author = getMetadata('author');
   const primaryTopic = getMetadata('primary-topic');
   const date = getMetadata('date');
 
+  const [authorTag, primaryTopicTag] = await Promise.all([getTag(author), getTag(primaryTopic)]);
+
   return {
     template,
     readTime,
-    author,
-    primaryTopic,
+    author: authorTag.title,
+    primaryTopic: primaryTopicTag.title,
     date,
   };
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -68,7 +68,7 @@ function createElement(tagName, attributes, ...children) {
 
 /**
  * Returns the tag information from a tagname
- * @param {string} tagName 
+ * @param {string} tagName
  * @returns {Promise} Object containing tag data or empty object if not exists
  * @property {string} title - The tag title
  * @property {string} tag - Tag path

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -16,7 +16,7 @@ function getDefaultLang() {
 /**
  * Taxonomy
  */
-const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';
+const taxonomyEndpoint = '/config/sidekick/taxonomy.json?sheet=tags';
 let taxonomyPromise = null;
 
 function fetchTaxonomy() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -6,7 +6,7 @@ import ffetch from './ffetch.js';
  * Language
  */
 function getCurrentLang() {
-  return 'en'; //TODO: Add logic
+  return 'en'; // TODO: Add logic
 }
 
 function getDefaultLang() {
@@ -19,7 +19,7 @@ function getDefaultLang() {
 const taxonomyEndpoint = 'https://main--cmegroup--aemsites.aem.live/config/sidekick/taxonomy-nestor.json?sheet=tags';
 let taxonomyPromise = null;
 
-function fetchTaxonomy(sheet) {
+function fetchTaxonomy() {
   if (!taxonomyPromise) {
     taxonomyPromise = new Promise((resolve, reject) => {
       (async () => {
@@ -32,7 +32,7 @@ function fetchTaxonomy(sheet) {
             taxonomy[row.tag] = {
               tag: row.tag,
               title: row[currentLang] && row[defaultLang],
-            }
+            };
           });
           resolve(taxonomy);
         } catch (e) {
@@ -68,16 +68,13 @@ function createElement(tagName, attributes, ...children) {
 
 /**
  * Returns the tag information from a tagname
- * 
  * @param {string} tagName 
  * @returns {Promise} Object containing tag data or empty object if not exists
  * @property {string} title - The tag title
  * @property {string} tag - Tag path
  */
 function getTag(tagFullName) {
-  return fetchTaxonomy().then((taxonomy) => {
-    return taxonomy[tagFullName];
-  });
+  return fetchTaxonomy().then((taxonomy) => taxonomy[tagFullName]);
 }
 
 /**

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -36,6 +36,7 @@
         base: '/config/sidekick/library.json',
         icons: '/tools/sidekick/library/plugins/icons/icons.js',
         tags: '/tools/sidekick/library/plugins/tags/tags.js',
+        templates: '/tools/sidekick/library/plugins/templates/templates.js',
   }
 
 

--- a/tools/sidekick/library/plugins/tags/tags.css
+++ b/tools/sidekick/library/plugins/tags/tags.css
@@ -53,7 +53,8 @@
   overflow-y: auto;
   padding: 0 1rem;
   background: var(--tag-bg-color);
-  height: calc(100vh - 200px);
+  height: calc(100vh - 100px);
+  display: flex;
 }
 
 .category-group {
@@ -61,6 +62,7 @@
   background: var(--category-bg);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  margin-right: 1.5rem;
 }
 
 .subcategory-group {
@@ -88,6 +90,10 @@
   width: 20px;
   text-align: center;
   color: #666;
+}
+
+.category-header:hover .category-selector {
+  visibility: visible;
 }
 
 .category-title {
@@ -136,6 +142,24 @@
 .cat-1 { --highlight-color: #2E7D32; background-color: #2E7D32; }
 .cat-2 { --highlight-color: #C62828; background-color: #C62828; }
 .cat-3 { --highlight-color: #6A1B9A; background-color: #6A1B9A; }
+
+.category-selector {
+  visibility: hidden;
+  height: 1.25rem;
+  padding: 0 0.25rem;
+  border-radius: 0.1875rem;
+  text-align: center;
+  opacity: 0.4;
+  display: inline;
+}
+  
+.category-selector:hover {
+  opacity: 1;
+}
+  
+.category-selector img {
+  filter: brightness(0) saturate(100%) invert(100%) sepia(0%) saturate(0%) hue-rotate(254deg) brightness(100%) contrast(103%);
+}
 
 #selected {
   background: var(--tag-bg-color);

--- a/tools/sidekick/library/plugins/tags/tags.css
+++ b/tools/sidekick/library/plugins/tags/tags.css
@@ -105,13 +105,12 @@
 }
 
 .path-wrapper {
-  padding: 0.3rem 0.5rem;
+  padding-left: 1rem;
   margin-left: 1.5rem;
 }
 
 .path {
   cursor: pointer;
-  padding: 0.5rem;
   border-radius: 4px;
   display: flex;
   flex-direction: column;

--- a/tools/sidekick/library/plugins/tags/tags.js
+++ b/tools/sidekick/library/plugins/tags/tags.js
@@ -24,7 +24,7 @@ function buildHierarchicalMenu(taxonomy) {
     const hasSubcategories = Object.keys(category).some((k) => !['title', 'name', 'path', 'hide'].includes(k));
     if (hasSubcategories) {
       menuItems.push(`
-        <div class="category-group collapsed" data-category="${catId}">
+        <div class="category-group" data-category="${catId}">
           <div class="category-header">
             <span class="expand-icon">+</span>
             <span class="category-title">${category.title}</span>
@@ -37,7 +37,7 @@ function buildHierarchicalMenu(taxonomy) {
           <span class="path" data-full-path="${category.path}">
             <span class="path-hierarchy" title="${category.path}"/>
             </span>
-            <span class="tag cat-${catId % 4}" data-title="${category.title}" data-path="${category.path}">
+            <span class="tag tag-data cat-${catId % 4}" data-title="${category.title}" data-path="${category.path}">
               ${category.title}
             </span>
           </span>
@@ -58,6 +58,9 @@ function buildHierarchicalMenu(taxonomy) {
               <div class="category-header">
                 <span class="expand-icon">+</span>
                 <span class="category-title">${item.title}</span>
+                <span class="category-selector path cat-${catId % 4} tag-data" data-title="${item.title}" data-full-path="${item.path}">
+                  <img src="/icons/check.svg"/>
+                </span>
               </div>
               <div class="category-content">
           `);
@@ -66,10 +69,10 @@ function buildHierarchicalMenu(taxonomy) {
         } else {
           menuItems.push(`
             <div class="path-wrapper">
-              <span class="path" data-full-path="${item.path}">
+              <span class="path" data-full-path="${item.path}" data-title="${item.title}">
                 <span class="path-hierarchy" title="${item.path}"/>
                 </span>
-                <span class="tag cat-${catId % 4}" data-title="${item.title}" data-path="${item.path}">
+                <span class="tag cat-${catId % 4} tag-data" data-title="${item.title}" data-path="${item.path}">
                   ${item.title}
                 </span>
               </span>
@@ -91,10 +94,10 @@ function buildHierarchicalMenu(taxonomy) {
 function displaySelected(container) {
   const selectedPaths = Array.from(container.querySelectorAll('.path.selected'))
     .map((path) => {
-      const { fullPath } = path.dataset;
+      const { fullPath, title } = path.dataset;
       return {
         fullPath,
-        label: path.querySelector('.tag').dataset.title,
+        label: title,
       };
     });
 
@@ -144,6 +147,14 @@ export async function decorateTagsPlugin(container, sheet) {
 
   // Event Handlers
   container.addEventListener('click', (e) => {
+    // Tag selection
+    const pathEl = e.target.closest('.path');
+    if (pathEl) {
+      pathEl.classList.toggle('selected');
+      displaySelected(container);
+      return;
+    }
+
     // Category expand/collapse
     const categoryHeader = e.target.closest('.category-header');
     if (categoryHeader) {
@@ -151,14 +162,6 @@ export async function decorateTagsPlugin(container, sheet) {
       const icon = categoryHeader.querySelector('.expand-icon');
       group.classList.toggle('collapsed');
       icon.textContent = group.classList.contains('collapsed') ? '+' : '−';
-      return;
-    }
-
-    // Tag selection
-    const pathEl = e.target.closest('.path');
-    if (pathEl) {
-      pathEl.classList.toggle('selected');
-      displaySelected(container);
     }
   });
 

--- a/tools/sidekick/library/plugins/tags/tags.js
+++ b/tools/sidekick/library/plugins/tags/tags.js
@@ -82,11 +82,11 @@ function displaySelected(container) {
     .map((path) => {
       const { fullPath } = path.dataset;
       // Split the path and remove the first segment (tags/ or template/)
-      const pathParts = fullPath.split('/');
-      const processedPath = pathParts.slice(1).join('/');
+      //const pathParts = fullPath.split('/');
+      //const processedPath = pathParts.slice(1).join('/');
 
       return {
-        fullPath: processedPath,
+        fullPath: fullPath,
         label: path.querySelector('.tag').dataset.title,
       };
     });

--- a/tools/sidekick/library/plugins/tags/tags.js
+++ b/tools/sidekick/library/plugins/tags/tags.js
@@ -34,7 +34,7 @@ function buildHierarchicalMenu(taxonomy) {
     } else {
       menuItems.push(`
         <div class="path-wrapper">
-          <span class="path" data-full-path="${category.path}">
+          <span class="path" data-full-path="${category.path}" data-title="${category.title}">
             <span class="path-hierarchy" title="${category.path}"/>
             </span>
             <span class="tag tag-data cat-${catId % 4}" data-title="${category.title}" data-path="${category.path}">

--- a/tools/sidekick/library/plugins/tags/tags.js
+++ b/tools/sidekick/library/plugins/tags/tags.js
@@ -21,14 +21,29 @@ function buildHierarchicalMenu(taxonomy) {
     if (category.hide) return;
 
     // Add main category
-    menuItems.push(`
-      <div class="category-group collapsed" data-category="${catId}">
-        <div class="category-header">
-          <span class="expand-icon">+</span>
-          <span class="category-title">${category.title}</span>
+    const hasSubcategories = Object.keys(category).some((k) => !['title', 'name', 'path', 'hide'].includes(k));
+    if (hasSubcategories) {
+      menuItems.push(`
+        <div class="category-group collapsed" data-category="${catId}">
+          <div class="category-header">
+            <span class="expand-icon">+</span>
+            <span class="category-title">${category.title}</span>
+          </div>
+          <div class="category-content">
+      `);
+    } else {
+      menuItems.push(`
+        <div class="path-wrapper">
+          <span class="path" data-full-path="${category.path}">
+            <span class="path-hierarchy" title="${category.path}"/>
+            </span>
+            <span class="tag cat-${catId % 4}" data-title="${category.title}" data-path="${category.path}">
+              ${category.title}
+            </span>
+          </span>
         </div>
-        <div class="category-content">
-    `);
+      `);
+    }
 
     const processLevel = (items, level = 0) => {
       Object.entries(items).forEach(([key, item]) => {
@@ -49,12 +64,6 @@ function buildHierarchicalMenu(taxonomy) {
           processLevel(item, level + 1);
           menuItems.push('</div></div>');
         } else {
-          // Add leaf tag item
-          const pathParts = item.path.split('/');
-          const displayPath = pathParts.length > 3
-            ? `.../${pathParts.slice(-2).join('/')}`
-            : pathParts.slice(0, -1).join('/');
-
           menuItems.push(`
             <div class="path-wrapper">
               <span class="path" data-full-path="${item.path}">
@@ -70,8 +79,10 @@ function buildHierarchicalMenu(taxonomy) {
       });
     };
 
-    processLevel(category);
-    menuItems.push('</div></div>');
+    if (hasSubcategories) {
+      processLevel(category);
+      menuItems.push('</div></div>');
+    }
   });
 
   return menuItems.join('');
@@ -109,8 +120,8 @@ function displaySelected(container) {
   }
 }
 
-export async function decorate(container) {
-  const taxonomy = await getTaxonomy();
+export async function decorateTagsPlugin(container, sheet) {
+  const taxonomy = await getTaxonomy(sheet);
 
   // Create container structure with selected section below filter
   container.innerHTML = `
@@ -223,6 +234,10 @@ export async function decorate(container) {
       category.style.display = hasVisiblePaths ? 'block' : 'none';
     });
   });
+}
+
+export async function decorate(container) {
+  decorateTagsPlugin(container, 'tags');
 }
 
 export default {

--- a/tools/sidekick/library/plugins/tags/tags.js
+++ b/tools/sidekick/library/plugins/tags/tags.js
@@ -81,12 +81,8 @@ function displaySelected(container) {
   const selectedPaths = Array.from(container.querySelectorAll('.path.selected'))
     .map((path) => {
       const { fullPath } = path.dataset;
-      // Split the path and remove the first segment (tags/ or template/)
-      //const pathParts = fullPath.split('/');
-      //const processedPath = pathParts.slice(1).join('/');
-
       return {
-        fullPath: fullPath,
+        fullPath,
         label: path.querySelector('.tag').dataset.title,
       };
     });

--- a/tools/sidekick/library/plugins/templates/templates.css
+++ b/tools/sidekick/library/plugins/templates/templates.css
@@ -1,0 +1,1 @@
+@import url('../tags/tags.css');

--- a/tools/sidekick/library/plugins/templates/templates.js
+++ b/tools/sidekick/library/plugins/templates/templates.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-vars */
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { decorateTagsPlugin } from '../tags/tags.js';
+
+export async function decorate(container) {
+  decorateTagsPlugin(container, 'templates');
+}
+
+export default {
+  title: 'Templates',
+};


### PR DESCRIPTION
Upgrades the tags plugin according to the new structure of the taxonomy spreadsheet.
Updates the hero block to pull the primary topic and author labels from taxonomy file.

Fix #93 

Test URLs:
- Before: https://main--cmegroup--aemsites.aem.page/tools/sidekick/library.html
- After: https://issue-93-tagging-enhancements--cmegroup--aemsites.aem.page/tools/sidekick/library.html

Sample of article pulling labels for hero from taxonomy file:

https://issue-93-tagging-enhancements--cmegroup--aemsites.aem.page/drafts/nestor/article1

Taxonomy file:

https://docs.google.com/spreadsheets/d/1bLDh0Ldn11-vwZKTbiYx1-w0gKveMXMoo07IvUZI30o/edit?gid=864386553#gid=864386553