### PR TITLE
Issue 24 translations

### DIFF
--- a/aemedge/blocks/cards/cards.js
+++ b/aemedge/blocks/cards/cards.js
@@ -1,10 +1,15 @@
 /* eslint-disable max-len */
 import { createOptimizedPicture, readBlockConfig } from '../../scripts/aem.js';
-import { createElement, parseTime, formatDate } from '../../scripts/utils.js';
+import {
+  createElement,
+  parseTime,
+  formatDate,
+  i18n,
+} from '../../scripts/utils.js';
 
 const QUERY_INDEX_ENDPOINT = '/query-index.json';
 
-function createStaticCards(block) {
+async function createStaticCards(block) {
   const cardsContainer = document.createElement('div');
   if (block.classList.contains('links')) {
     const cardTitle = document.createElement('h6');
@@ -58,6 +63,13 @@ function createStaticCards(block) {
     }
     cardsContainer.append(mainContainer);
   } else if (block.classList.contains('static')) {
+    const [
+      readLabel,
+      watchLabel,
+    ] = await Promise.all([
+      i18n('read'),
+      i18n('watch'),
+    ]);
     const ul = document.createElement('ul');
     [...block.children].forEach((row) => {
       const li = document.createElement('li');
@@ -83,7 +95,7 @@ function createStaticCards(block) {
       cardSubtitle.className = 'cards-subtitle';
       const cardTime = document.createElement('span');
       cardTime.className = 'cards-time';
-      cardTime.innerText = `${time} ${format === 'video' ? 'Watch' : 'read'}`;
+      cardTime.innerText = `${time} ${format === 'video' ? watchLabel : readLabel}`;
       const cardDate = document.createElement('span');
       cardDate.className = 'cards-date';
       cardDate.innerText = date;
@@ -149,7 +161,7 @@ export function createDynamicCard({
   return li;
 }
 
-export function createDynamicCardArticle({ content }) {
+export async function createDynamicCardArticle({ content }) {
   const { dynamicProperties } = content;
   const {
     path,
@@ -159,6 +171,13 @@ export function createDynamicCardArticle({ content }) {
     date,
     title,
   } = dynamicProperties;
+  const [
+    readLabel,
+    watchLabel,
+  ] = await Promise.all([
+    i18n('read'),
+    i18n('watch'),
+  ]);
 
   const li = document.createElement('li');
   const linkEl = document.createElement('a');
@@ -179,7 +198,7 @@ export function createDynamicCardArticle({ content }) {
 
   const cardTime = document.createElement('span');
   cardTime.className = 'cards-time';
-  cardTime.innerText = `${duration} ${mediaType === 'video-webinar' ? 'Watch' : 'read'}`;
+  cardTime.innerText = `${duration} ${mediaType === 'video-webinar' ? watchLabel : readLabel}`;
 
   const cardDate = document.createElement('span');
   cardDate.className = 'cards-date';
@@ -267,7 +286,7 @@ export default async function decorate(block) {
     cards = cardsContainer;
   } else {
     // Default to static mode
-    cards = createStaticCards(block);
+    cards = await createStaticCards(block);
   }
 
   if (cards) {

--- a/aemedge/blocks/cards/cards.js
+++ b/aemedge/blocks/cards/cards.js
@@ -279,7 +279,7 @@ export default async function decorate(block) {
     } else {
       const { endpoint } = config;
       filteredData = await fetchAndFilterDataArticle(endpoint);
-      cardElements = filteredData.map(createDynamicCardArticle);
+      cardElements = await Promise.all(filteredData.map(createDynamicCardArticle));
     }
     ul.append(...cardElements);
     cardsContainer.append(ul);

--- a/aemedge/blocks/faq/faq.js
+++ b/aemedge/blocks/faq/faq.js
@@ -1,9 +1,10 @@
-import { createElement, addDividerLine } from '../../scripts/utils.js';
+import { createElement, addDividerLine, i18n } from '../../scripts/utils.js';
 
-function addBackToTopLink(row) {
+async function addBackToTopLink(row) {
+  const backToTopLabel = await i18n('Back to Top');
   const topIconImg = createElement('img', { src: '/aemedge/icons/chevron-up.svg' });
   const topIconSpan = createElement('span', { class: 'icon icon-chevron-up' }, topIconImg);
-  const linkText = createElement('span', null, 'Back to Top');
+  const linkText = createElement('span', null, backToTopLabel);
   const link = createElement('a', { href: '#top', class: 'back-to-top' }, topIconSpan, linkText);
   row.appendChild(link);
 }

--- a/aemedge/blocks/hero/hero-article.css
+++ b/aemedge/blocks/hero/hero-article.css
@@ -94,6 +94,7 @@
   flex-basis: 100%;
   order: 1;
   margin-top: 1rem;
+  text-transform: uppercase;
 }
 
 .hero.article .row > *:first-child {

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -1,9 +1,20 @@
-import { createElement, getArticleRelatedMetadata } from '../../scripts/utils.js';
+import { createElement, getArticleRelatedMetadata, i18n } from '../../scripts/utils.js';
 
 async function decorateArticlePageHero(block) {
-  const {
-    readTime, author, primaryTopic, date,
-  } = await getArticleRelatedMetadata();
+  const [
+    {
+      readTime, author, primaryTopic, date,
+    },
+    readLabel,
+    saveLabel,
+    byLabel,
+  ] = await Promise.all([
+    getArticleRelatedMetadata(),
+    i18n('read'),
+    i18n('Save'),
+    i18n('By'),
+  ]);
+
   const h1 = block.querySelector('h1');
   const readIcon = createElement('img', {
     src: '/aemedge/icons/list.svg',
@@ -12,7 +23,7 @@ async function decorateArticlePageHero(block) {
   });
 
   const readIconSpan = readTime ? createElement('span', { class: 'icon icon-list' }, readIcon) : null;
-  const readTimeText = readTime ? createElement('span', null, `${readTime} READ`) : null;
+  const readTimeText = readTime ? createElement('span', null, `${readTime} ${readLabel}`) : null;
   const articleTime = createElement('span', { class: 'article-time' }, readIconSpan, readTimeText);
   const featuredTag = primaryTopic ? createElement('span', { class: 'article-featured-tag' }, primaryTopic) : null;
   const saveIconOutlined = createElement('img', {
@@ -27,11 +38,11 @@ async function decorateArticlePageHero(block) {
     loading: 'lazy',
   });
   const saveIconFilledSpan = createElement('span', { class: 'icon icon-bookmark-filled' }, saveIconFilled);
-  const saveText = createElement('span', { class: 'save-text' }, 'Save');
+  const saveText = createElement('span', { class: 'save-text' }, saveLabel);
   const bookmarkButton = createElement('a', { class: 'bookmark' }, saveIconOutlinedSpan, saveIconFilledSpan, saveText);
   const row1 = createElement('div', { class: 'row' }, articleTime, featuredTag, bookmarkButton);
   const row2 = createElement('div', { class: 'row article-title' }, h1);
-  const authorText = `By ${author}`;
+  const authorText = `${byLabel} ${author}`;
   const authors = author ? createElement('span', { class: 'authors' }, authorText) : null;
   const articleDate = date ? createElement('span', { class: 'article-date' }, date) : null;
   const row3 = createElement('div', { class: 'row' }, authors, articleDate);
@@ -57,10 +68,10 @@ function decorateGenericHero(block) {
   contentDiv.classList.add('container');
 }
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const isArticleVariant = block.classList.contains('article');
   if (isArticleVariant) {
-    decorateArticlePageHero(block);
+    await decorateArticlePageHero(block);
   } else {
     decorateGenericHero(block);
   }

--- a/aemedge/scripts/taxonomy.js
+++ b/aemedge/scripts/taxonomy.js
@@ -1,6 +1,6 @@
 import ffetch from './ffetch.js';
 
-const taxonomyEndpoint = '/config/sidekick/taxonomy.json';
+const taxonomyEndpoint = '/config/taxonomy.json';
 const taxonomyPromises = {};
 
 function fetchTaxonomy(sheet) {

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -6,7 +6,7 @@ import ffetch from './ffetch.js';
  * Language
  */
 function getCurrentLang() {
-  return 'en'; // TODO: Add logic
+  return getMetadata('locale');
 }
 
 function getDefaultLang() {
@@ -16,7 +16,7 @@ function getDefaultLang() {
 /**
  * Taxonomy
  */
-const taxonomyEndpoint = '/config/sidekick/taxonomy.json?sheet=tags';
+const taxonomyEndpoint = '/config/taxonomy.json?sheet=tags';
 let taxonomyPromise = null;
 
 function fetchTaxonomy() {
@@ -31,7 +31,7 @@ function fetchTaxonomy() {
           taxonomyJson.forEach((row) => {
             taxonomy[row.tag] = {
               tag: row.tag,
-              title: row[currentLang] && row[defaultLang],
+              title: row[currentLang] || row[defaultLang],
             };
           });
           resolve(taxonomy);
@@ -42,6 +42,34 @@ function fetchTaxonomy() {
     });
   }
   return taxonomyPromise;
+}
+
+/**
+ * Translations
+ */
+const translationsEndpoint = '/config/translations.json';
+let translationsPromise = null;
+
+function fetchTranslations() {
+  if (!translationsPromise) {
+    translationsPromise = new Promise((resolve, reject) => {
+      (async () => {
+        try {
+          const currentLang = getCurrentLang();
+          const defaultLang = getDefaultLang();
+          const translationsJson = await ffetch(`${translationsEndpoint}?sheet=${currentLang || defaultLang}`).all();
+          const translations = {};
+          translationsJson.forEach((row) => {
+            translations[row.k] = row.v;
+          });
+          resolve(translations);
+        } catch (e) {
+          reject(e);
+        }
+      })();
+    });
+  }
+  return translationsPromise;
 }
 
 /**
@@ -75,6 +103,15 @@ function createElement(tagName, attributes, ...children) {
  */
 function getTag(tagFullName) {
   return fetchTaxonomy().then((taxonomy) => taxonomy[tagFullName]);
+}
+
+/**
+ * Returns the tag information from a tagname
+ * @param {string} label to translate
+ * @returns {Promise} Object containing the value of the translation or the key if not present
+ */
+function i18n(key) {
+  return fetchTranslations().then((translations) => translations[key] || key);
 }
 
 /**
@@ -151,4 +188,6 @@ export {
   addDividerLine,
   parseTime,
   formatDate,
+  getTag,
+  i18n,
 };

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -47,7 +47,7 @@ function fetchTaxonomy() {
 /**
  * Translations
  */
-const translationsEndpoint = '/config/translations.json';
+const translationsEndpoint = '/eds-config/translations.json';
 let translationsPromise = null;
 
 function fetchTranslations() {


### PR DESCRIPTION
- Added the translations file in gdrive at /cmegroup/eds-config/translations
- Added i18n utility function in JS to get the translation for a text
- Updated blocks to use the translations: hero, cards, faq

Fix #24

Test URLs:
- Before: https://main--cmegroup--aemsites.aem.live/education
- After: https://issue-24-translations--cmegroup--aemsites.aem.live/education

- Before: https://main--cmegroup--aemsites.aem.live/drafts/nestor/article1
- After: https://issue-24-translations--cmegroup--aemsites.aem.live/drafts/nestor/article1
