### PR TITLE
Adding Assets plugin to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -7,6 +7,20 @@
         "environments": ["edit"],
         "url": "/tools/sidekick/library.html",
         "includePaths": ["**.docx**"]
+      },
+      {
+        "id": "asset-library",
+        "title": "My Assets",
+        "environments": [
+            "edit"
+        ],
+        "url": "https://experience.adobe.com/solutions/CQ-helix-assets-addon/static-assets/resources/asset-selector.html",
+        "isPalette": true,
+        "includePaths": [
+            "**.docx**"
+        ],
+        "passConfig": true,
+        "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
       }
     ]
   }


### PR DESCRIPTION
Adding Assets plugin to sidekick

Test URLs:
- Before: https://main--cmegroup--aemsites.aem.live/
- After: https://assets-plugin--cmegroup--aemsites.aem.live/
