### PR TITLE
Adding oneTrust SDK

### DIFF
--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -1,12 +1,58 @@
-import { loadScript } from './aem.js';
+import { sampleRUM, loadScript } from './aem.js';
+import { getEnvType } from './utils.js';
 
 // add delayed functionality here
-function loadShareThis() {
-  loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=644646a57ac381001a304496&product=sticky-share-buttons&source=platform');
+async function loadShareThis() {
+  return loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=644646a57ac381001a304496&product=sticky-share-buttons&source=platform');
+}
+
+async function loadOneTrust() {
+  if (getEnvType() !== 'prod') {
+    return Promise.resolve();
+  }
+
+  const ONETRUST_CONFIG = {
+    stubScript: {
+      url: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+      options: {
+        type: 'text/javascript',
+        charset: 'UTF-8',
+      },
+    },
+    mainScript: {
+      url: 'https://cdn.cookielaw.org/consent/f42915b0-68e5-491a-a7f7-1db0d962ddff/OtAutoBlock.js',
+      options: {
+        type: 'text/javascript',
+        charset: 'UTF-8',
+        'data-domain-script': 'f42915b0-68e5-491a-a7f7-1db0d962ddff',
+      },
+    },
+  };
+
+  try {
+    await loadScript(ONETRUST_CONFIG.stubScript.url, ONETRUST_CONFIG.stubScript.options);
+    await loadScript(ONETRUST_CONFIG.mainScript.url, ONETRUST_CONFIG.mainScript.options);
+    if (!window.OneTrust) {
+      throw new Error('OneTrust failed to initialize');
+    }
+    return Promise.resolve();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('OneTrust loading failed:', error);
+    return Promise.resolve();
+  }
 }
 
 function loadPage() {
-  loadShareThis();
+  sampleRUM('delayed:start');
+  Promise.all([
+    loadShareThis(),
+    loadOneTrust(),
+  ]).then(() => {
+    sampleRUM('delayed:end');
+  }).catch((error) => {
+    sampleRUM('delayed:error', error);
+  });
 }
 
 loadPage();

--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -1,9 +1,11 @@
 import { sampleRUM, loadScript } from './aem.js';
 import { getEnvType } from './utils.js';
 
-// add delayed functionality here
-async function loadShareThis() {
-  return loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=644646a57ac381001a304496&product=sticky-share-buttons&source=platform');
+// Core Web Vitals RUM collection
+sampleRUM('cwv');
+
+function loadShareThis() {
+  loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=644646a57ac381001a304496&product=sticky-share-buttons&source=platform');
 }
 
 async function loadOneTrust() {
@@ -44,15 +46,8 @@ async function loadOneTrust() {
 }
 
 function loadPage() {
-  sampleRUM('delayed:start');
-  Promise.all([
-    loadShareThis(),
-    loadOneTrust(),
-  ]).then(() => {
-    sampleRUM('delayed:end');
-  }).catch((error) => {
-    sampleRUM('delayed:error', error);
-  });
+  loadShareThis();
+  loadOneTrust();
 }
 
 loadPage();

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -200,6 +200,17 @@ function formatDate(dateString) {
   return `${day} ${month}`;
 }
 
+function getEnvType() {
+  const prodEnvs = [
+    'cmegroup.com',
+    'www.cmegroup.com',
+    'main--cmegroup--aemsites.aem.page',
+    'main--cmegroup--aemsites.hlx.live',
+  ];
+  const type = prodEnvs.includes(window.location.hostname) ? 'prod' : 'stage';
+  return type;
+}
+
 export {
   createElement,
   getArticleRelatedMetadata,
@@ -209,4 +220,5 @@ export {
   getTag,
   i18n,
   getPageTags,
+  getEnvType,
 };


### PR DESCRIPTION
Added oneTrust SDK for prod only environments

Fix #14 

Test URLs:
- Before: https://main--cmegroup--aemsites.aem.live/education
- After: https://issue-14--cmegroup--aemsites.aem.live/education
