### PR TITLE
Original Sidekick library to preview blocks within DA context for ease of authoring 

### DIFF
--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="Description" content="AEM Sidekick Library" />
+    <meta name="robots" content="noindex" />
+    <base href="/" />
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: sans-serif;
+        background-color: #ededed;
+        height: 100%;
+      }
+      
+      helix-sidekick { display: none }
+    </style>
+    <title>Sidekick Library</title>
+  </head>
+
+  <body>
+    <script
+      type="module"
+      src="https://www.aem.live/tools/sidekick/library/index.js"
+    ></script>
+    <script>
+      const library = document.createElement('sidekick-library')
+      library.config = {
+        base: '/eds-config/sidekick/blocks.json',
+      }
+
+      document.body.prepend(library)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Original Sidekick library to preview blocks within DA context for ease of authoring 

**_Preview Blocks Library_** plugin can be tested via opening DA url : https://da.live/edit?ref=preview-blocks#/cmegroup/www/education

sidekick config.json now committed in the config bus looks like below
```
    {
      "id": "previewblocklibrary",
      "title": "Preview Block Library",
      "environments": [
        "edit"
      ],
      "daLibrary": true,
      "includePaths": [
        "DA"
      ],
      "experience": "fullsize-dialog",
      "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
      "path": "/tools/sidekick/library.html"
    }
```

Test URLs:
- Before: https://main--wwww--cmegroup.aem.live/
- After: https://preview-blocks--www--cmegroup.aem.live/
