### PR TITLE
Scheduler Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Before using the aem-boilerplate, we recommand you to go through the documentati
 3. [Web Performance](https://www.aem.live/developer/keeping-it-100)
 4. [Markup, Sections, Blocks, and Auto Blocking](https://www.aem.live/developer/markup-sections-blocks)
 
+
+## Plugins
+
+- For local development, sidekick plugins can be configured at /tools/sidekick/config.json
+- For DA environments, sidekick plugins must be registered in the config bus using the Admin API. See [here](https://www.aem.live/docs/admin.html#schema/SidekickConfig) for more details.
+
 ## Installation
 
 ```sh

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,80 @@
+ {
+    "project": "cmegroup.com",
+    "editUrlLabel": "Document Authoring",
+    "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}{{pathname}}",
+    "plugins": [
+      {
+        "id": "library",
+        "title": "Library",
+        "environments": [
+          "edit"
+        ]
+      },
+      {
+        "id": "previewblocklibrary",
+        "title": "Preview Block Library",
+        "environments": [
+          "edit"
+        ],
+        "daLibrary": true,
+        "includePaths": [
+          "DA"
+        ],
+        "experience": "fullsize-dialog",
+        "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
+        "path": "/tools/sidekick/library.html"
+      },
+      {
+        "id": "onpremAssets",
+        "title": "Assets - On-Premise",
+        "environments": [
+          "edit"
+        ],
+        "daLibrary": true,
+        "includePaths": [
+          "DA"
+        ],
+        "experience": "window",
+        "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
+        "url": "https://web-beta-author01.cmegroup.com/aem/assetpicker.html"
+      },
+      {
+        "id": "tagger",
+        "title": "Tag Browser",
+        "environments": [
+          "edit"
+        ],
+        "daLibrary": true,
+        "includePaths": [
+          "DA"
+        ],
+        "experience": "fullsize-dialog",
+        "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
+        "path": "/tools/sidekick/tagger/tagger.html"
+      },
+      {
+        "id": "courseorder",
+        "title": "Course Order",
+        "environments": [
+          "edit"
+        ],
+        "daLibrary": true,
+        "includePaths": [
+          "DA"
+        ],
+        "experience": "dialog",
+        "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
+        "path": "/tools/sidekick/courseorder/courseorder.html"
+      },
+      {
+        "id": "scheduler",
+        "title": "Scheduler", 
+        "environments": ["edit"],
+        "daLibrary": true,
+        "includePaths": ["DA"],
+        "experience": "dialog",
+        "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
+        "path": "/tools/sidekick/scheduler/scheduler.html"
+      }
+    ]
+  }

--- a/tools/sidekick/scheduler/scheduler.css
+++ b/tools/sidekick/scheduler/scheduler.css
@@ -1,0 +1,305 @@
+:root {
+    --blue: #4d7bff;
+    --font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+    --border-color: #e0e0e0;
+    --error-color: #d92020;
+    --text-primary: #4b4b4b;
+    --text-secondary: #666;
+    --background-disabled: #f8f8f8;
+    --background-schedule: #f5f5f5;
+    --focus-outline: rgb(22 122 243);
+    --button-border: rgb(0 0 0);
+    --white: white;
+  }
+  
+  .scheduler-form-wrapper {
+    padding: 20px;
+    font-family: var(--font-family);
+  }
+  
+  .input-group, .message-wrapper {
+    margin-bottom: 15px;
+    font-family: var(--font-family);
+    font-size: 14px;
+    line-height: 1.2;
+    word-wrap: break-word;
+  }
+  
+  .message-wrapper.hidden {
+    display: none;
+  }
+  
+  .message-wrapper {
+    font-style: italic;
+    color: var(--text-secondary);
+    flex: 1;
+    margin-right: 20px;
+  }
+  
+  .message-wrapper .message {
+    display: inline-block;
+  }
+  
+  .message-wrapper:hover {
+    box-shadow: none;
+  }
+  
+  .message-wrapper .message.error {
+    color: #800000;
+  }
+  
+  label {
+    font-family: var(--font-family);
+    font-size: 14px;
+    color: #444;
+  }
+  
+  .input-group label {
+    display: block;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+    font-size: 14px;
+  }
+  
+  .input-group input {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--white);
+  }
+  
+  .input-group input[readonly] {
+    background-color: var(--background-disabled);
+    max-width: 95%;
+  }
+  
+  .button-group {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 20px -20px 0;
+    padding: 20px 20px 0;
+    border-top: 2px solid var(--border-color);
+  }
+  
+  .button-actions {
+    display: flex;
+    gap: 10px;
+  }
+  
+  .button-group button,
+  .custom-button {
+    padding: 8px 16px;
+    line-height: 18px;
+    font-size: 14px;
+    border: 2px solid var(--button-border);
+    color: var(--button-border);
+    border-radius: 16px;
+    outline-offset: 0;
+    text-decoration: none;
+    font-weight: 700;
+    text-align: center;
+    cursor: pointer;
+    background: none;
+    height: 35px;
+  }
+  
+  .button-group button:focus,
+  .custom-button:focus {
+    outline: 2px solid var(--focus-outline);
+    outline-offset: 2px;
+  }
+  
+  .docs-button {
+    background-color: transparent;
+  }
+  
+  .button-group button.schedule-button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-color: var(--blue);
+    background-color: var(--blue);
+    color: var(--white);
+    padding: 8px 16px;
+  }
+  
+  .button-group button.schedule-button img {
+    width: 16px;
+    height: 16px;
+    filter: brightness(100);
+  }
+  
+  .custom-input {
+    display: none;
+  }
+  
+  .custom-input.visible {
+    display: block;
+  }
+  
+  .cron-expression-container {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    align-items: center;
+  }
+  
+  .cron-expression-container input[type="date"],
+  .cron-expression-container input[type="time"],
+  .cron-expression-container .custom-input {
+    height: 35px;
+    padding: 0 8px;
+    box-sizing: border-box;
+    font-family: var(--font-family);
+  }
+  
+  .cron-expression-container.custom-mode {
+    display: flex;
+    gap: 10px;
+  }
+  
+  .cron-expression-container.custom-mode .custom-input {
+    flex: 1;
+    display: block;
+    height: 35px;
+    padding: 0 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--white);
+    margin: 0;
+  }
+  
+  .action-select {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--white);
+    margin-bottom: 15px;
+  }
+  
+  .current-schedule {
+    background-color: var(--background-schedule);
+    padding: 15px;
+    border-radius: 4px;
+    margin: 15px 0;
+    border: 1px solid var(--border-color);
+  }
+  
+  .current-schedule-label {
+    font-size: 14px;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  
+  .current-schedule-label .info-icon {
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+  }
+  
+  .schedule-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background-color: transparent;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 0;
+  }
+  
+  .schedule-row:last-child {
+    border-bottom: none;
+  }
+  
+  .schedule-action {
+    font-weight: normal;
+  }
+  
+  .schedule-time {
+    color: var(--text-secondary);
+  }
+  
+  .input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  
+  select.schedule-input {
+    appearance: none;
+    background-color: white;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    background-size: 16px;
+    padding-right: 32px;
+  }
+  
+  .input-group label::after {
+    content: ' *';
+    color: var(--error-color);
+  }
+  
+  @media (forced-colors: active) {
+    .schedule-input:focus,
+    .schedule-btn:focus {
+      outline: 2px solid CanvasText;
+    }
+  }
+  
+  .cron-expression-container .custom-button {
+    padding: 8px 16px;
+    height: 35px;
+    margin-bottom: 0;
+  }
+  
+  .cron-expression-container input[disabled] {
+    background-color: var(--background-disabled);
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+  
+  .cron-expression-container input[disabled]:hover {
+    border-color: var(--border-color);
+  }
+  
+  .cron-expression-container.custom-mode input[type="date"],
+  .cron-expression-container.custom-mode input[type="time"] {
+    display: none;
+  }
+  
+  .input-empty {
+    border-color: var(--error-color) !important;
+  }
+  
+  .button-group button:focus-visible,
+  .custom-button:focus-visible,
+  .action-select:focus-visible,
+  input:focus-visible {
+    outline: 2px solid var(--focus-outline);
+    outline-offset: 2px;
+  }
+  
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  
+  .schedule-row:focus-within {
+    outline: 2px solid var(--focus-outline);
+    outline-offset: -2px;
+  }

--- a/tools/sidekick/scheduler/scheduler.html
+++ b/tools/sidekick/scheduler/scheduler.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Scheduler</title>
+  <link rel="stylesheet" href="scheduler.css">
+</head>
+<body>
+  <div class="scheduler-form-wrapper">
+    <form class="scheduler-form" role="form" aria-label="Schedule page form">
+      <div class="input-group">
+        <label for="page-path">Page</label>
+        <input type="text" id="page-path" readonly aria-label="Current page path">
+      </div>
+
+      <div class="input-group">
+        <label for="action-select">Action</label>
+        <select id="action-select" class="action-select" aria-label="Select action to schedule">
+          <option value="preview">Preview</option>
+          <option value="publish">Publish</option>
+          <option value="unpublish">Unpublish</option>
+        </select>
+      </div>
+
+      <div class="input-group">
+        <label for="date-input">When</label>
+        <div class="cron-expression-container" role="group" aria-label="Schedule date and time">
+          <input type="date" id="date-input" aria-label="Schedule date">
+          <input type="time" id="time-input" aria-label="Schedule time">
+          <button type="button" class="custom-button" aria-label="Switch to custom cron expression">Custom</button>
+          <input type="text" class="custom-input" id="custom-input" placeholder="Enter cron expression" aria-label="Custom cron expression">
+        </div>
+      </div>
+
+      <div class="current-schedule-label" role="heading" aria-level="2">
+        <span>Active Schedules </span>
+        <img src="/.da/icons/info-icon.png" class="info-icon" alt="Information" role="img" aria-label="Schedule information">
+      </div>
+
+      <div class="current-schedule" role="region" aria-label="Active schedules">
+        <div class="schedule-content"></div>
+      </div>
+
+      <div class="button-group">
+        <div class="message-wrapper" role="status" aria-live="polite">
+          <span class="message"></span>
+        </div>
+        <div class="button-actions">
+          <button type="button" class="docs-button" aria-label="Open scheduling documentation in new tab">Read Documentation</button>
+          <button type="button" class="schedule-button" aria-label="Schedule the selected action">
+            <img src="/.da/icons/pending-icon.png" alt="">
+            Schedule
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+  <script type="module" src="scheduler.js"></script>
+</body>
+</html>

--- a/tools/sidekick/scheduler/scheduler.js
+++ b/tools/sidekick/scheduler/scheduler.js
@@ -1,0 +1,426 @@
+/* eslint-disable import/no-absolute-path */
+/* eslint-disable no-console */
+/* eslint-disable eol-last */
+/* eslint-disable import/no-unresolved */
+
+// Import SDK for Document Authoring
+import DA_SDK from 'https://da.live/nx/utils/sdk.js';
+
+// Base URL for Document Authoring source
+const DA_SOURCE = 'https://admin.da.live/source';
+const CRON_TAB_PATH = '.helix/crontab.json';
+const AEM_PREVIEW_REQUEST_URL = 'https://admin.hlx.page/preview';
+
+// Combine message handling into a single utility
+const messageUtils = {
+  container: document.querySelector('.message-wrapper'),
+  show(text, isError = false) {
+    const message = this.container.querySelector('.message');
+    message.innerHTML = text.replace(/\r?\n/g, '<br>');
+    message.classList.toggle('error', isError);
+  },
+  setLoading(loading) {
+    this.container.classList.toggle('loading', loading);
+    this.container.classList.toggle('regular', !loading);
+  },
+};
+
+/**
+ * Shows existing schedules for the current path in the feedback container
+ * @param {string} path - Current page path to check schedules for
+ * @param {Object} json - Crontab data object
+ * @param {Array} json.data - Array of schedule entries
+ */
+function displaySchedules(path, json) {
+  if (!json?.data?.length) {
+    messageUtils.show(`No scheduling data available for ${path}`, true);
+    return;
+  }
+
+  const schedules = json.data.filter((row) => row.command.includes(path));
+  if (!schedules.length) {
+    messageUtils.show(`No scheduling data available for ${path}`, true);
+    return;
+  }
+
+  const scheduleList = schedules
+    .map((row) => `${row.command.split(' ')[0]}ing ${row.when}`)
+    .join('\r\n');
+  messageUtils.show(`Schedules for ${path}:\r\n${scheduleList}`);
+}
+
+/**
+ * Previews the crontab file
+ * @param {string} url - API endpoint URL
+ * @param {Object} opts - Request options
+ * @param {string} opts.method - HTTP method (POST)
+ * @returns {Promise<void>}
+ */
+async function previewCronTab(url, opts) {
+  const newOpts = { ...opts, method: 'POST' };
+  const previewReqUrl = url.replace(DA_SOURCE, AEM_PREVIEW_REQUEST_URL).replace(CRON_TAB_PATH, `main/${CRON_TAB_PATH}`);
+  try {
+    const resp = await fetch(previewReqUrl, newOpts);
+    if (!resp.ok) {
+      messageUtils.show('Failed to activate schedule , please check console for more details', true);
+      return false;
+    }
+    return true;
+  } finally {
+    messageUtils.setLoading(false);
+  }
+}
+
+/**
+ * Sends updated scheduling data to the server
+ * @param {string} url - API endpoint URL
+ * @param {Object} opts - Request options including body and method
+ * @param {FormData} opts.body - Form data containing updated schedule
+ * @param {string} opts.method - HTTP method (POST)
+ * @returns {Promise<Object|null>} Parsed JSON response or null if failed
+ */
+async function setSchedules(url, opts) {
+  // Send request
+  try {
+    const resp = await fetch(url, opts);
+    if (!resp.ok) {
+      throw new Error(`Failed to set schedules: ${resp.status}`);
+    }
+    return resp.json();
+  } catch (error) {
+    console.error(error.message);
+    messageUtils.show('Failed to save schedule, please check console for more details', true);
+    return null;
+  }
+}
+
+// Add the cleanupPastSchedules function near the top with other utility functions
+function cleanupPastSchedules(json) {
+  if (!json?.data?.length) return json;
+
+  const now = new Date();
+  const cleanedData = json.data.filter((schedule) => {
+    const match = schedule.when.match(/at (\d+:\d+\s*(?:AM|PM)) on the (\d+)(?:st|nd|rd|th) day of (\w+) in (\d+)/i);
+    if (!match) return true;
+
+    const [, timeStr, day, month, year] = match;
+    const monthIndex = new Date(`${month} 1, 2000`).getMonth();
+
+    const [hours, minutes] = timeStr.match(/(\d+):(\d+)/).slice(1);
+    let hour = parseInt(hours, 10);
+    const minute = parseInt(minutes, 10);
+    if (timeStr.toUpperCase().includes('PM') && hour < 12) hour += 12;
+    if (timeStr.toUpperCase().includes('AM') && hour === 12) hour = 0;
+
+    const scheduleDate = new Date(Date.UTC(
+      parseInt(year, 10),
+      monthIndex,
+      parseInt(day, 10),
+      hour,
+      minute,
+    ));
+
+    return scheduleDate > now;
+  });
+
+  return { ...json, data: cleanedData };
+}
+
+/**
+ * Fetches current scheduling data from the server
+ * @param {string} url - API endpoint URL
+ * @param {Object} opts - Request options
+ * @param {string} opts.method - HTTP method (GET)
+ * @param {Object} opts.headers - Request headers including auth token
+ * @returns {Promise<Object|null>} Parsed JSON response or null if failed
+ */
+async function getSchedules(url, opts) {
+  try {
+    const resp = await fetch(url, opts);
+    if (!resp.ok) {
+      throw new Error(`Failed to fetch schedules: ${resp.status}`);
+    }
+    const json = await resp.json();
+
+    // Clean up past schedules before returning
+    const cleanedJson = cleanupPastSchedules(json);
+
+    // If schedules were removed, update the crontab
+    if (cleanedJson.data.length < json.data.length) {
+      const body = new FormData();
+      body.append('data', new Blob([JSON.stringify(cleanedJson)], { type: 'application/json' }));
+
+      // Update crontab with cleaned data
+      await setSchedules(url, { ...opts, body, method: 'POST' });
+
+      // Preview the changes
+      await previewCronTab(url, opts);
+    }
+
+    return cleanedJson;
+  } catch (error) {
+    console.error(error.message);
+    messageUtils.show('Failed to fetch, please check console for more details', true);
+    return null;
+  }
+}
+
+// Update the createCronExpression function
+function createCronExpression(localDate) {
+  const utcDate = new Date(localDate.toUTCString());
+  const day = utcDate.getUTCDate();
+  const suffix = ['th', 'st', 'nd', 'rd'][(day % 10 > 3 || day < 21) ? 0 : day % 10];
+
+  // Format time separately
+  const timeFormatter = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'UTC',
+  });
+
+  // Format month separately
+  const monthFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    timeZone: 'UTC',
+  });
+
+  return `at ${timeFormatter.format(utcDate)} on the ${day}${suffix} day of ${
+    monthFormatter.format(utcDate)
+  } in ${utcDate.getUTCFullYear()}`;
+}
+
+/**
+ * Processes a schedule command by updating the crontab
+ * @param {string} url - API endpoint URL
+ * @param {Object} opts - Request options
+ * @param {string} command - Command type ('preview' or 'publish')
+ * @param {string} pagePath - Path of page to schedule
+ * @param {string} cronExpression - Schedule expression
+ * @returns {Promise<boolean>} True if successful, false otherwise
+ */
+async function processCommand(url, opts, command, pagePath, cronExpression) {
+  if (!cronExpression?.trim()) return false;
+
+  const json = await getSchedules(url, opts);
+  if (!json) {
+    messageUtils.show(`Please make sure ${CRON_TAB_PATH} is present and is accessible`, true);
+    return false;
+  }
+
+  const existingCommand = `${command} ${pagePath}`;
+
+  json.data = [
+    ...json.data.filter((row) => row.command !== existingCommand),
+    { when: cronExpression.trim(), command: existingCommand },
+  ];
+
+  const body = new FormData();
+  body.append('data', new Blob([JSON.stringify(json)], { type: 'application/json' }));
+
+  const newJson = await setSchedules(url, { ...opts, body, method: 'POST' });
+  if (!newJson) return false;
+
+  // Only clear message and show schedules if preview is successful
+  const previewSuccess = await previewCronTab(url, opts);
+  if (previewSuccess) {
+    messageUtils.show('');
+    displaySchedules(pagePath, await getSchedules(url, opts));
+    return true;
+  }
+  return false;
+}
+
+// Update showCurrentSchedule function's date parsing logic:
+function showCurrentSchedule(path, json) {
+  const schedules = json.data.filter((row) => row.command.includes(path));
+  const content = document.querySelector('.schedule-content');
+
+  if (schedules.length === 0) {
+    content.textContent = 'No active schedules found';
+  } else {
+    content.innerHTML = '';
+    schedules.forEach((schedule) => {
+      const row = document.createElement('div');
+      row.className = 'schedule-row';
+
+      const action = document.createElement('div');
+      action.className = 'schedule-action';
+      const actionText = schedule.command.split(' ')[0];
+      action.textContent = actionText.charAt(0).toUpperCase() + actionText.slice(1);
+
+      const time = document.createElement('div');
+      time.className = 'schedule-time';
+
+      // Convert UTC schedule time to local time for display
+      const whenParts = schedule.when.match(/at (.*?) on the/);
+      if (whenParts) {
+        const utcTimeStr = whenParts[1];
+        const utcDateStr = schedule.when.match(/the (\d+).*? day of (.*?) in (\d+)/);
+        if (utcDateStr) {
+          const [, day, month, year] = utcDateStr;
+          // Create a proper date string that JavaScript can parse
+          const monthIndex = new Date(`${month} 1, 2000`).getMonth(); // Get month index (0-11)
+          const utcDate = new Date(Date.UTC(
+            year,
+            monthIndex,
+            day,
+            ...utcTimeStr.match(/(\d+):(\d+)/).slice(1).map(Number),
+          ));
+
+          const timeFormatter = new Intl.DateTimeFormat('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          });
+          const dateFormatter = new Intl.DateTimeFormat('en-US', {
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+          });
+
+          const formattedTime = timeFormatter.format(utcDate);
+          const formattedDate = dateFormatter.format(utcDate);
+          time.textContent = `at ${formattedTime} on ${formattedDate}`;
+        } else {
+          time.textContent = schedule.when;
+        }
+      } else {
+        time.textContent = schedule.when;
+      }
+
+      row.append(action, time);
+      content.appendChild(row);
+    });
+  }
+}
+
+// Add validation function for future date/time
+function isDateTimeInFuture(dateStr, timeStr) {
+  const selectedDateTime = new Date(`${dateStr}T${timeStr}`);
+  const now = new Date();
+  return selectedDateTime > now;
+}
+
+/**
+ * Initializes the scheduler interface
+ * @returns {Promise<void>}
+ */
+async function init() {
+  const { context, token } = await DA_SDK;
+
+  // Set page path
+  const pageInput = document.getElementById('page-path');
+  pageInput.value = context.path;
+
+  // Handle custom button
+  const customButton = document.querySelector('.custom-button');
+  const cronExpressionContainer = document.querySelector('.cron-expression-container');
+  const customInput = document.querySelector('.custom-input');
+  const dateInput = document.querySelector('#date-input');
+  const timeInput = document.querySelector('#time-input');
+
+  // Set current date and time as default values
+  const now = new Date();
+  const [dateValue] = now.toISOString().split('T');
+  dateInput.value = dateValue;
+  timeInput.value = now.toTimeString().slice(0, 5);
+
+  customButton.addEventListener('click', () => {
+    const isCustom = !cronExpressionContainer.classList.contains('custom-mode');
+    cronExpressionContainer.classList.toggle('custom-mode');
+
+    // Clear any existing empty states
+    [dateInput, timeInput, customInput].forEach((input) => {
+      input.classList.remove('input-empty');
+    });
+
+    if (isCustom) {
+      customInput.remove();
+      cronExpressionContainer.insertBefore(customInput, customButton);
+    } else {
+      customInput.remove();
+      const whenGroup = document.querySelector('.input-group:has(#date-input)');
+      whenGroup.appendChild(customInput);
+    }
+  });
+
+  // Handle docs button
+  const docsButton = document.querySelector('.docs-button');
+  docsButton.addEventListener('click', () => {
+    window.open('https://www.aem.live/docs/scheduling', '_blank');
+  });
+  const url = `${DA_SOURCE}/${context.org}/${context.repo}/${CRON_TAB_PATH}`;
+  const opts = {
+    headers: {
+      Authorization: `Bearer: ${token}`,
+    },
+  };
+  // Handle schedule button
+  const scheduleButton = document.querySelector('.schedule-button');
+  scheduleButton.addEventListener('click', async (e) => {
+    e.preventDefault();
+
+    const action = document.querySelector('.action-select').value;
+    const isCustomMode = cronExpressionContainer.classList.contains('custom-mode');
+
+    // Clear previous empty states
+    [dateInput, timeInput, customInput].forEach((input) => {
+      input.classList.remove('input-empty');
+    });
+
+    // Check for empty inputs and future date/time based on mode
+    if (isCustomMode) {
+      if (!customInput.value) {
+        customInput.classList.add('input-empty');
+        return;
+      }
+    } else {
+      let hasError = false;
+      if (!dateInput.value) {
+        dateInput.classList.add('input-empty');
+        hasError = true;
+      }
+      if (!timeInput.value) {
+        timeInput.classList.add('input-empty');
+        hasError = true;
+      }
+      if (hasError) return;
+
+      // Validate if date/time is in the future
+      if (!isDateTimeInFuture(dateInput.value, timeInput.value)) {
+        dateInput.classList.add('input-empty');
+        timeInput.classList.add('input-empty');
+        messageUtils.show('Please select a future date and time', true);
+        return;
+      }
+    }
+
+    let cronExpression;
+    if (isCustomMode) {
+      cronExpression = customInput.value;
+    } else {
+      const localDate = new Date(`${dateInput.value}T${timeInput.value}`);
+      cronExpression = createCronExpression(localDate);
+    }
+
+    messageUtils.show('Scheduling page...');
+    const success = await processCommand(url, opts, action, context.path, cronExpression);
+    if (success) {
+      messageUtils.show('');
+      // Fetch and update current schedules after successful scheduling
+      const json = await getSchedules(url, opts);
+      if (json && json.data) {
+        showCurrentSchedule(context.path, json);
+      }
+    }
+  });
+
+  // Check existing schedules
+  const json = await getSchedules(url, opts);
+  if (json && json.data) {
+    showCurrentSchedule(context.path, json);
+  }
+}
+
+init();


### PR DESCRIPTION
This PR introduces a new plugin to give the authors an ability to schedule pages for preview, publish, unpublish. 

The mechanism at the backend still remains the same where the cron expressions are committed to crontab sheet under **/cmegroup/www/.helix/crontab**

More details to understand how scheduling works in Edge Delivery, Refer to https://www.aem.live/docs/scheduling

Also, added a note to ReadMe how to go about plugin development for local and DA environments.

Fix #110 

You can see the scheduler plugin in action at https://da.live/edit?ref=issue110-scheduler#/cmegroup/www/drafts/kunwar/test-doc


sidekick config.json now committed in the config bus looks like below
```
{
        "id": "scheduler",
        "title": "Scheduler", 
        "environments": ["edit"],
        "daLibrary": true,
        "includePaths": ["DA"],
        "experience": "dialog",
        "icon": "https://da.live/blocks/edit/img/Smock_Images_18_N.svg",
        "path": "/tools/sidekick/scheduler/scheduler.html"
      }
```

Test URLs:
- Before: https://main--wwww--cmegroup.aem.live/education
- After: https://issue110-scheduler--www--cmegroup.aem.live/education
