### PR TITLE
External Links behavior

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -139,6 +139,27 @@ function buildAutoBlocks(main) {
 }
 
 /**
+ * Decorates external links to open in a new tab.
+ * @param {Element} main The main element
+ */
+export function decorateExternalLinks(main) {
+  main.querySelectorAll('a').forEach((a) => {
+    const href = a.getAttribute('href');
+    if (href) {
+      const extension = href.split('.').pop().trim();
+      const isExternal = !href.startsWith('/') && !href.startsWith('#');
+      const isPDF = extension === 'pdf';
+      const isCMEGroup = href.includes('cmegroup.com');
+      const hasLinkOverride = a.querySelector('code') !== null;
+
+      if (isPDF || (isExternal && !isCMEGroup) || (isCMEGroup && hasLinkOverride)) {
+        a.setAttribute('target', '_blank');
+      }
+    }
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
@@ -150,6 +171,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  decorateExternalLinks(main);
 }
 
 /**

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -299,18 +299,27 @@ p {
 }
 
 /* links */
-a {
+a,
+a code {
     color: var(--link-color);
     text-decoration: none;
+    font-family: inherit;
+    font-size: inherit;
 }
 
-a:hover {
+a:hover,
+a:hover code {
     color: var(--link-hover-color);
     text-decoration: underline;
+    font-family: inherit;
+    font-size: inherit;
 }
 
-a:visited {
+a:visited,
+a:visited code {
     color: var(--link-color);
+    font-family: inherit;
+    font-size: inherit;
 }
 
 /* ul */


### PR DESCRIPTION
In this PR, External Links behavior is added such that authors can override the default link target mechanism (same page) and open in a new window/tab (target=_blank). By default, external urls and pdf links open in a new window/tab

**Author flow**
- Author creates a link in a normal way
- Let it be if they want to open in the same page
- If they want to override, Just select the link and Add extra formatting using ‘**inline code toggle**’
- Preview/Publish

For demo, see this screencast : https://www.loom.com/share/3a4e45c45f974ccdbed0695f4418cb4e

More details on slack discussion : https://adobe-dx-support.slack.com/archives/C06PK80B5A5/p1744905271267909

Test URLs:
- Before: https://main--www--cmegroup.aem.live/drafts/kunwar/links
- After: https://links--www--cmegroup.aem.live/drafts/kunwar/links
