### PR TITLE
Issue 238: Tags exclusions on tags cloud block

### DIFF
--- a/aemedge/blocks/tags-cloud/tags-cloud.js
+++ b/aemedge/blocks/tags-cloud/tags-cloud.js
@@ -1,14 +1,54 @@
 import { readBlockConfig } from '../../scripts/aem.js';
 import { i18n, getPageTags, createElement } from '../../scripts/utils.js';
+import ffetch from '../../scripts/ffetch.js';
 
 const defaultUrl = '/education/browse-all';
 
-function buildTagList(block, tagsLablel, tags, listPage) {
-  if (!tags) return;
+/**
+ * Tags Cloud Exclusions
+ */
+const tagsCloudExclusionsEndpoint = '/eds-config/tags-cloud-exclusions.json';
+let tagsCloudExclusionsPromise = null;
+
+function fetchTagsCloudExclusions() {
+  if (!tagsCloudExclusionsPromise) {
+    tagsCloudExclusionsPromise = new Promise((resolve, reject) => {
+      (async () => {
+        try {
+          const tagsCloudExclusionsJson = await ffetch(`${tagsCloudExclusionsEndpoint}`).all();
+          const tagsCloudExclusions = [];
+          tagsCloudExclusionsJson.forEach((row) => {
+            tagsCloudExclusions.push(row.tag);
+          });
+          resolve(tagsCloudExclusions);
+        } catch (e) {
+          reject(e);
+        }
+      })();
+    });
+  }
+  return tagsCloudExclusionsPromise;
+}
+
+async function filterIncludedTags(tags) {
+  const exclusions = await fetchTagsCloudExclusions();
+  return tags.filter((tag) => !exclusions.some((exclusion) => (
+    exclusion.endsWith('/')
+      ? tag.name.startsWith(exclusion)
+      : tag.name === exclusion)));
+}
+
+/**
+ * Build tags list
+ */
+async function buildTagList(block, tagsLablel, tags, listPage) {
+  if (!tags || tags.length === 0) return;
+  const filteredTags = await filterIncludedTags(tags);
+  if (!filteredTags || filteredTags.length === 0) return;
   const titleSpan = createElement('span', { class: 'tag-label' });
   titleSpan.textContent = `${tagsLablel}:`;
   block.append(titleSpan);
-  tags.forEach((tag) => {
+  filteredTags.forEach(async (tag) => {
     const { name, title } = tag;
     const button = createElement('a', {
       class: 'btn-tag-filter',

--- a/aemedge/blocks/tags-cloud/tags-cloud.js
+++ b/aemedge/blocks/tags-cloud/tags-cloud.js
@@ -4,6 +4,9 @@ import ffetch from '../../scripts/ffetch.js';
 
 const defaultUrl = '/education/browse-all';
 
+const CACHE_KEY = 'tags_exclusions_cache';
+const CACHE_DURATION = 15 * 60 * 1000;
+
 /**
  * Tags Cloud Exclusions
  */
@@ -15,11 +18,24 @@ function fetchTagsCloudExclusions() {
     tagsCloudExclusionsPromise = new Promise((resolve, reject) => {
       (async () => {
         try {
+          const cached = localStorage.getItem(CACHE_KEY);
+          if (cached) {
+            const parsed = JSON.parse(cached);
+            if (parsed.timestamp && parsed.exclusions
+              && Date.now() - parsed.timestamp < CACHE_DURATION) {
+              resolve(parsed.exclusions);
+              return;
+            }
+          }
           const tagsCloudExclusionsJson = await ffetch(`${tagsCloudExclusionsEndpoint}`).all();
           const tagsCloudExclusions = [];
           tagsCloudExclusionsJson.forEach((row) => {
             tagsCloudExclusions.push(row.tag);
           });
+          localStorage.setItem(CACHE_KEY, JSON.stringify({
+            timestamp: Date.now(),
+            exclusions: tagsCloudExclusions,
+          }));
           resolve(tagsCloudExclusions);
         } catch (e) {
           reject(e);

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -166,8 +166,14 @@ async function getArticleRelatedMetadata() {
  */
 async function getPageTags() {
   const metadataTags = getMetadata('article:tag');
+  if (!metadataTags || metadataTags.trim() === '') {
+    return [];
+  }
   const mapTag = async (tagName) => {
     const finalName = tagName.trim();
+    if (!finalName) {
+      return null;
+    }
     const tag = await getTag(finalName);
     return {
       name: finalName,


### PR DESCRIPTION
Updates the tags cloud block to show only the tags not included in the exclusions list.

The exclusion list can be configured at:
https://da.live/sheet#/cmegroup/www/eds-config/tags-cloud-exclusions

Fix #238 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/drafts/nestor/article1
- After: https://issue-238-tags-exclusions--www--cmegroup.aem.page/drafts/nestor/article1
