### PR TITLE
Issue 152 table block fixed row column

### DIFF
--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -238,6 +238,7 @@
     position: sticky;
     top: 0;
     z-index: 1;
+    transition: top 0.3s ease;
 }
 
 @media (width <= 480px) {

--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -224,3 +224,101 @@
     width: 100%;
   }
 }
+
+.table.fixed-row-header {
+    overflow: inherit;
+    width: 100%;
+}
+
+.table.fixed-row-header table {
+    position: relative;
+}
+
+.table.fixed-row-header table th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+@media (width <= 480px) {
+    .table.fixed-column-xs {
+        overflow: auto;
+    }
+
+    .table.fixed-column-xs table th:first-child {
+        left: 0;
+        z-index: 2;
+    }
+
+    .table.fixed-column-xs table tbody td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+    }
+}
+
+@media (width <= 768px) {
+    .table.fixed-column-s {
+        overflow: auto;
+    }
+
+    .table.fixed-column-s table th:first-child {
+        left: 0;
+        z-index: 2;
+    }
+
+    .table.fixed-column-s table tbody td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+    }
+}
+
+@media (width <= 992px) {
+    .table.fixed-column-m {
+        overflow: auto;
+    }
+
+    .table.fixed-column-m table th:first-child {
+        left: 0;
+        z-index: 2;
+    }
+
+    .table.fixed-column-m table tbody td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+    }
+}
+
+@media (width <= 1200px) {
+    .table.fixed-column-l {
+        overflow: auto;
+    }
+
+    .table.fixed-column-l table th:first-child {
+        left: 0;
+        z-index: 2;
+    }
+
+    .table.fixed-column-l table tbody td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+    }
+}
+
+.table.fixed-column-xl {
+    overflow: auto;
+}
+
+.table.fixed-column-xl table th:first-child {
+    left: 0;
+    z-index: 2;
+}
+
+.table.fixed-column-xl table tbody td:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+}

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -174,7 +174,11 @@ export default async function decorate(block) {
   }
   store.subscribe(({ floatingElements }) => floatingElements, ({ height }) => {
     document.querySelectorAll('.table.fixed-row-header thead th').forEach((th) => {
-      th.style.top = `${height}px`;
+      if (getComputedStyle(th.closest('.table')).overflow === 'auto') {
+        th.style.top = 'auto';
+      } else {
+        th.style.top = `${height}px`;
+      }
     });
   });
 }

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -170,4 +170,12 @@ export default async function decorate(block) {
       }
     });
   }
+
+  document.addEventListener('floatingElementsChange', (e) => {
+    const { height, navbarVisible } = e.detail;
+    const top = navbarVisible ? height : 0;
+    document.querySelectorAll('.table.fixed-row-header thead th').forEach((th) => {
+      th.style.top = `${top}px`;
+    });
+  });
 }

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -1,3 +1,5 @@
+import { store } from '../../scripts/store/store.js';
+
 function buildCell(colspan = 1, rowspan = 1, header = false) {
   const cell = header ? document.createElement('th') : document.createElement('td');
   if (colspan > 1) cell.setAttribute('colspan', colspan);
@@ -170,12 +172,9 @@ export default async function decorate(block) {
       }
     });
   }
-
-  document.addEventListener('floatingElementsChange', (e) => {
-    const { height, navbarVisible } = e.detail;
-    const top = navbarVisible ? height : 0;
+  store.subscribe(({ floatingElements }) => floatingElements, ({ height }) => {
     document.querySelectorAll('.table.fixed-row-header thead th').forEach((th) => {
-      th.style.top = `${top}px`;
+      th.style.top = `${height}px`;
     });
   });
 }

--- a/aemedge/scripts/actions/floatingElements.js
+++ b/aemedge/scripts/actions/floatingElements.js
@@ -1,0 +1,15 @@
+import { FLOATING_ELEMENTS_ACTIONS } from '../constants/index.js';
+
+export function stackFloatingElement(height) {
+  return {
+    type: FLOATING_ELEMENTS_ACTIONS.STACK,
+    payload: height,
+  };
+}
+
+export function unstackFloatingElement(height) {
+  return {
+    type: FLOATING_ELEMENTS_ACTIONS.UNSTACK,
+    payload: height,
+  };
+}

--- a/aemedge/scripts/actions/floatingElements.js
+++ b/aemedge/scripts/actions/floatingElements.js
@@ -1,15 +1,18 @@
+/* eslint-disable import/prefer-default-export */
 import { FLOATING_ELEMENTS_ACTIONS } from '../constants/index.js';
 
-export function stackFloatingElement(height) {
+export function updateFloatingElements() {
   return {
-    type: FLOATING_ELEMENTS_ACTIONS.STACK,
-    payload: height,
+    type: FLOATING_ELEMENTS_ACTIONS.UPDATE,
   };
 }
 
-export function unstackFloatingElement(height) {
+export function addFloatingElement(element, callback) {
   return {
-    type: FLOATING_ELEMENTS_ACTIONS.UNSTACK,
-    payload: height,
+    type: FLOATING_ELEMENTS_ACTIONS.ADD,
+    payload: {
+      element,
+      callback,
+    },
   };
 }

--- a/aemedge/scripts/alerts/alerts.js
+++ b/aemedge/scripts/alerts/alerts.js
@@ -5,6 +5,8 @@
 import { getMetadata } from '../aem.js';
 import { getBrowserName, formatToCentralTime } from '../utils.js';
 import { getLegacyAlerts } from '../legacy-api.js';
+import { store } from '../store/store.js';
+import { stackFloatingElement, unstackFloatingElement } from '../actions/floatingElements.js';
 
 const CACHE_KEY = 'alerts_cache';
 const CACHE_DURATION = 15 * 60 * 1000;
@@ -190,6 +192,7 @@ export default async function initFloatingElements(doc, header) {
   let lastScrollTop = 0;
   const main = doc.querySelector('main');
   const alerts = doc.querySelectorAll('.alert-item');
+  let lastOffsetTop = 0;
 
   if (alertsFetched.length) {
     const updatePositions = () => {
@@ -211,6 +214,10 @@ export default async function initFloatingElements(doc, header) {
       if (menuOpen) {
         menuOpen.style.top = `${offsetTop}px`;
       }
+      if (offsetTop !== lastOffsetTop) {
+        store.dispatch(stackFloatingElement(offsetTop - lastOffsetTop));
+        lastOffsetTop = offsetTop;
+      }
     };
 
     const observer = new MutationObserver(updatePositions);
@@ -225,6 +232,8 @@ export default async function initFloatingElements(doc, header) {
     });
 
     updatePositions();
+  } else {
+    store.dispatch(stackFloatingElement(header.offsetHeight));
   }
 
   window.addEventListener('scroll', () => {
@@ -233,20 +242,17 @@ export default async function initFloatingElements(doc, header) {
     if (scrollTop > lastScrollTop) {
       changed = !header.classList.contains('hidden');
       header.classList.add('hidden');
+      if (changed) {
+        store.dispatch(unstackFloatingElement(header.offsetHeight));
+      }
     } else {
       changed = header.classList.contains('hidden');
       header.classList.remove('hidden');
+      if (changed) {
+        store.dispatch(stackFloatingElement(header.offsetHeight));
+      }
     }
     lastScrollTop = scrollTop;
-    if (changed) {
-      const event = new CustomEvent('floatingElementsChange', {
-        detail: {
-          height: header.offsetHeight,
-          navbarVisible: !header.classList.contains('hidden'),
-        },
-      });
-      doc.dispatchEvent(event);
-    }
   });
 
   return Promise.resolve();

--- a/aemedge/scripts/alerts/alerts.js
+++ b/aemedge/scripts/alerts/alerts.js
@@ -229,12 +229,24 @@ export default async function initFloatingElements(doc, header) {
 
   window.addEventListener('scroll', () => {
     const scrollTop = window.pageYOffset || doc.documentElement.scrollTop;
+    let changed = false;
     if (scrollTop > lastScrollTop) {
+      changed = !header.classList.contains('hidden');
       header.classList.add('hidden');
     } else {
+      changed = header.classList.contains('hidden');
       header.classList.remove('hidden');
     }
     lastScrollTop = scrollTop;
+    if (changed) {
+      const event = new CustomEvent('floatingElementsChange', {
+        detail: {
+          height: header.offsetHeight,
+          navbarVisible: !header.classList.contains('hidden'),
+        },
+      });
+      doc.dispatchEvent(event);
+    }
   });
 
   return Promise.resolve();

--- a/aemedge/scripts/alerts/alerts.js
+++ b/aemedge/scripts/alerts/alerts.js
@@ -6,7 +6,7 @@ import { getMetadata } from '../aem.js';
 import { getBrowserName, formatToCentralTime } from '../utils.js';
 import { getLegacyAlerts } from '../legacy-api.js';
 import { store } from '../store/store.js';
-import { stackFloatingElement, unstackFloatingElement } from '../actions/floatingElements.js';
+import { addFloatingElement, updateFloatingElements } from '../actions/floatingElements.js';
 
 const CACHE_KEY = 'alerts_cache';
 const CACHE_DURATION = 15 * 60 * 1000;
@@ -192,7 +192,6 @@ export default async function initFloatingElements(doc, header) {
   let lastScrollTop = 0;
   const main = doc.querySelector('main');
   const alerts = doc.querySelectorAll('.alert-item');
-  let lastOffsetTop = 0;
 
   if (alertsFetched.length) {
     const updatePositions = () => {
@@ -214,10 +213,6 @@ export default async function initFloatingElements(doc, header) {
       if (menuOpen) {
         menuOpen.style.top = `${offsetTop}px`;
       }
-      if (offsetTop !== lastOffsetTop) {
-        store.dispatch(stackFloatingElement(offsetTop - lastOffsetTop));
-        lastOffsetTop = offsetTop;
-      }
     };
 
     const observer = new MutationObserver(updatePositions);
@@ -232,28 +227,37 @@ export default async function initFloatingElements(doc, header) {
     });
 
     updatePositions();
-  } else {
-    store.dispatch(stackFloatingElement(header.offsetHeight));
   }
 
   window.addEventListener('scroll', () => {
     const scrollTop = window.pageYOffset || doc.documentElement.scrollTop;
-    let changed = false;
     if (scrollTop > lastScrollTop) {
-      changed = !header.classList.contains('hidden');
-      header.classList.add('hidden');
-      if (changed) {
-        store.dispatch(unstackFloatingElement(header.offsetHeight));
+      if (!header.classList.contains('hidden')) {
+        header.classList.add('hidden');
       }
-    } else {
-      changed = header.classList.contains('hidden');
+    } else if (header.classList.contains('hidden')) {
       header.classList.remove('hidden');
-      if (changed) {
-        store.dispatch(stackFloatingElement(header.offsetHeight));
-      }
     }
     lastScrollTop = scrollTop;
   });
+
+  const resizeObserver = new ResizeObserver(() => {
+    store.dispatch(updateFloatingElements());
+  });
+  resizeObserver.observe(header);
+  const mutationObserver = new MutationObserver(() => {
+    store.dispatch(updateFloatingElements());
+  });
+  mutationObserver.observe(header, {
+    attributes: true,
+  });
+
+  store.dispatch(addFloatingElement(header, (element) => (element.classList.contains('hidden') ? 0 : element.offsetHeight)));
+  Array.from(alerts).forEach((elem) => {
+    store.dispatch(addFloatingElement(elem));
+    resizeObserver.observe(elem);
+  });
+  store.dispatch(updateFloatingElements());
 
   return Promise.resolve();
 }

--- a/aemedge/scripts/constants/floatingElements.js
+++ b/aemedge/scripts/constants/floatingElements.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const FLOATING_ELEMENTS_ACTIONS = {
+  STACK: 'STACK',
+  UNSTACK: 'UNSTACK',
+};

--- a/aemedge/scripts/constants/floatingElements.js
+++ b/aemedge/scripts/constants/floatingElements.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
 export const FLOATING_ELEMENTS_ACTIONS = {
-  STACK: 'STACK',
-  UNSTACK: 'UNSTACK',
+  ADD: 'ADD',
+  UPDATE: 'UPDATE',
 };

--- a/aemedge/scripts/constants/index.js
+++ b/aemedge/scripts/constants/index.js
@@ -1,1 +1,2 @@
 export * from './auth.js';
+export * from './floatingElements.js';

--- a/aemedge/scripts/reducers/floatingElements.js
+++ b/aemedge/scripts/reducers/floatingElements.js
@@ -1,0 +1,21 @@
+import { FLOATING_ELEMENTS_ACTIONS } from '../constants/index.js';
+
+export const floatingElementsInitState = {
+  height: 0,
+};
+
+// eslint-disable-next-line default-param-last
+export const floatingElementsReducer = (state = floatingElementsInitState, action) => {
+  switch (action.type) {
+    case FLOATING_ELEMENTS_ACTIONS.STACK:
+      return {
+        height: state.height + action.payload,
+      };
+    case FLOATING_ELEMENTS_ACTIONS.UNSTACK:
+      return {
+        height: state.height - action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/aemedge/scripts/reducers/floatingElements.js
+++ b/aemedge/scripts/reducers/floatingElements.js
@@ -1,20 +1,39 @@
 import { FLOATING_ELEMENTS_ACTIONS } from '../constants/index.js';
 
 export const floatingElementsInitState = {
+  elements: [],
+  callbacks: [],
   height: 0,
 };
+
+function calculateHeight(elements, callbacks) {
+  return elements.reduce((sum, elem, index) => {
+    const callback = callbacks[index];
+    if (callback) {
+      return sum + callback(elem);
+    }
+    return sum + elem.offsetHeight;
+  }, 0);
+}
 
 // eslint-disable-next-line default-param-last
 export const floatingElementsReducer = (state = floatingElementsInitState, action) => {
   switch (action.type) {
-    case FLOATING_ELEMENTS_ACTIONS.STACK:
+    case FLOATING_ELEMENTS_ACTIONS.UPDATE:
       return {
-        height: state.height + action.payload,
+        elements: state.elements,
+        callbacks: state.callbacks,
+        height: calculateHeight(state.elements, state.callbacks),
       };
-    case FLOATING_ELEMENTS_ACTIONS.UNSTACK:
+    case FLOATING_ELEMENTS_ACTIONS.ADD: {
+      const newElements = [...state.elements, action.payload.element];
+      const newCallbacks = [...state.callbacks, action.payload.callback];
       return {
-        height: state.height - action.payload,
+        elements: newElements,
+        callbacks: newCallbacks,
+        height: calculateHeight(newElements, newCallbacks),
       };
+    }
     default:
       return state;
   }

--- a/aemedge/scripts/store/store.js
+++ b/aemedge/scripts/store/store.js
@@ -1,4 +1,5 @@
 import { authInitState, authReducer } from '../reducers/auth.js';
+import { floatingElementsInitState, floatingElementsReducer } from '../reducers/floatingElements.js';
 
 class Store {
   constructor(reducer, initialState = {}) {
@@ -63,9 +64,11 @@ function combineReducers(reducers) {
 
 const rootReducer = combineReducers({
   authentication: authReducer,
+  floatingElements: floatingElementsReducer,
 });
 
 // eslint-disable-next-line import/prefer-default-export
 export const store = new Store(rootReducer, {
   authentication: authInitState,
+  floatingElements: floatingElementsInitState,
 });


### PR DESCRIPTION
Allow the table block to have a sticky table header and sticky first column (sticky column option can be set for different breakpoints).
Adds the FloatingElements to the store in order to manage the floating elements (navbar, alerts) and place the table header according to the visible floating elements (more floating elements will come in the future).

Fix #152 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/drafts/nestor/tables
- After: https://issue-152-table-block-fixed-row-column--www--cmegroup.aem.page/drafts/nestor/tables
