### PR TITLE
Calendar table fixs

### DIFF
--- a/aemedge/blocks/event-calendar/event-calendar.css
+++ b/aemedge/blocks/event-calendar/event-calendar.css
@@ -1351,6 +1351,7 @@
         font-weight: 600;
         font-family: var(--averta);
         padding-right: 0;
+        text-transform: uppercase;
     }
 
     .event-calendar-container .result-list-table-section .event-calendar-table-container .event-calendar-resume-wrapper span::before {
@@ -1733,6 +1734,12 @@
 .event-calendar-container .result-list-table-section .event-calendar-table-container .event-calendar-table .event-calendar-table-tbody .event-accordion-card .event-accordion-card-header .event-container ul li:nth-child(3) a:hover {
     color: var(--blue5);
     text-decoration: none;
+}
+
+.event-calendar-container .result-list-table-section .event-calendar-table-container .event-calendar-table .event-calendar-table-tbody .event-accordion-card .event-accordion-card-header .event-container ul li:nth-child(3) a .event-name {
+    max-width: 9.375rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .event-calendar-container .result-list-table-section .event-calendar-table-container .event-calendar-table .event-calendar-table-tbody .event-accordion-card .event-accordion-card-header .event-container ul li:nth-child(3) a .icon{

--- a/aemedge/blocks/event-calendar/event-calendar.js
+++ b/aemedge/blocks/event-calendar/event-calendar.js
@@ -285,6 +285,8 @@ function handleInputSearch(e) {
       getLeftPanelDays();
       getEvents();
     }, 400);
+  } else if (filterSearchInputContainer.contains(cleanInput)) {
+    cleanInput.remove();
   }
 }
 

--- a/aemedge/blocks/event-calendar/event-calendar.js
+++ b/aemedge/blocks/event-calendar/event-calendar.js
@@ -5,7 +5,7 @@ import {
   postEconomicReleaseDates,
   postEconomicReleaseEvents,
 } from '../../scripts/services/ProductCalendarService.js';
-import { URIUtil } from '../../scripts/utils/index.js';
+import { URIUtil, escapeHtmlTags } from '../../scripts/utils/index.js';
 
 const uriUtil = new URIUtil('', URIUtil.ARRAY_COMMA_ENCODE);
 const { body } = window.document;
@@ -273,12 +273,11 @@ function decorateCleanInputSearch() {
   cleanInput.addEventListener('click', async () => {
     cleanInputSearch();
   });
-  return cleanInput;
 }
 
 function handleInputSearch(e) {
   searchValueVar = e.target.value;
-  filterSearchInputContainer.append(decorateCleanInputSearch());
+  filterSearchInputContainer.append(cleanInput);
   if (searchValueVar !== '' && window.innerWidth >= 1200) {
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => {
@@ -585,6 +584,7 @@ function renderInputs() {
   const inputsFlexContainer = createElement('div', { class: 'inputs-flex-container' });
   filterSearchInput.placeholder = searchByEventLabel;
   filterSearchInputContainer.append(filterSearchInput);
+  decorateCleanInputSearch();
   inputsFlexContainer.append(filterSearchInputContainer);
 
   if (economicFilters && economicFilters.countries) {
@@ -939,7 +939,10 @@ function renderDesktopAccordion(eventsToRender) {
               <span class="highlight">${title}</span>
               <div class="main-content">
                 <div class="left-section">
-                  <p class="text">${text}</p>
+                  <p class="text">${escapeHtmlTags(text, ['br'])?.replace(
+      /<br\s*\/?>\s*(<br\s*\/?>)+/g,
+      '<br>',
+    )}</p>
                   <div class="more">
                     <span class="icon"></span>
                     <a href=${url}>Read more</a>
@@ -1041,7 +1044,10 @@ function renderMobileAccordion(eventsToRender) {
             <div class="expandable-content mobile">
               <div class="main-content">
                 <span class="highlight">${title}</span>
-                <p class="text">${text}</p>
+                <p class="text"><p class="text">${escapeHtmlTags(text, ['br'])?.replace(
+      /<br\s*\/?>\s*(<br\s*\/?>)+/g,
+      '<br>',
+    )}</p>
                 <div class="tags-section">
                   <span class="bold">Tags:</span>
                   <div>

--- a/aemedge/scripts/utils/misc.js
+++ b/aemedge/scripts/utils/misc.js
@@ -309,3 +309,33 @@ export function find(collection, predicate, fromIndex = 0) {
 
   return undefined;
 }
+
+export function escapeHtmlTags(str, exceptions) {
+  const regexPattern = '<\\/?[^>]+>';
+  const regex = new RegExp(regexPattern, 'g');
+  const tagStack = [];
+
+  return str?.replace(regex, (match) => {
+    const isClosingTag = match[1] === '/';
+    const currentMatch = match?.match(/<\/?(\w+)/);
+    const tagName = (currentMatch && currentMatch[1]) || '';
+
+    if (exceptions.length === 0) {
+      return '';
+    }
+
+    if (exceptions.includes(tagName)) {
+      if (!isClosingTag) {
+        tagStack.push(tagName);
+      } else if (
+        tagStack.length > 0
+        && tagStack[tagStack.length - 1] === tagName
+      ) {
+        tagStack.pop();
+      }
+      return match;
+    }
+
+    return '';
+  });
+}


### PR DESCRIPTION
CUEN-255 - clear x in empty search box
CUEN-254 - date css capitalized fix
CUEN-253 - glitchy service call on clear search box
CUEN-252 - extra BR in texts removed
CUEN-251 - ellipsis for long titles in accordion

Test URLs:
- Before: https://main--www--cmegroup.aem.live/
- After: https://calendar-table-fixs--www--cmegroup.aem.live/drafts/ramiro/event-calendar
