### PR TITLE
Fix #236 Add text highlighting support.

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -316,6 +316,58 @@ function decorateExternalImages(ele) {
 }
 
 /**
+ * Decorates author's text highlights in the main element.
+ * Author can select text to highlight via "inline code".
+ * Author can set the highlight color in the section metadata via "text-highlight" property.
+ *
+ * The highlight color is determined by the data-text-highlight attribute on the outer section div.
+ * <div class="section" data-section-status="loaded" data-text-highlight="bg-green" style="">
+ * If the attribute is not present no decoration will be applied.
+ *
+ * Before:
+ * <p>
+ *   ...other text
+ *   <code>
+ *     PLACEHOLDER -> Text the content author highlighted here.
+ *   </code>
+ *   ... other text
+ * </p>
+ *
+ * After:
+ * <p>
+ *   ...other text
+ *   <b><span class="bg-green"><span class="blue2">
+ *     PLACEHOLDER -> Text the content author highlighted here.
+ *   </span></span></b>
+ *   ... other text
+ * </p>
+ *
+ * @param {Element} main The main element
+ */
+function decorateTextHighlights(main) {
+  // Find <code> elements inside <p> elements within main
+  const codeElements = main.querySelectorAll('p code');
+  codeElements.forEach((codeEl) => {
+    // For each code element, find the closest section and its desired highlight color
+    const sectionDiv = codeEl.closest('.section');
+    const highlightColor = sectionDiv ? sectionDiv.getAttribute('data-text-highlight') : null;
+
+    if (highlightColor) {
+      const highlightedText = codeEl.textContent.trim();
+      const highlightBoldEl = document.createElement('b');
+      const highlightOutterSpanEl = document.createElement('span');
+      highlightOutterSpanEl.className = highlightColor;
+      const highlightSpanEl = document.createElement('span');
+      highlightSpanEl.className = 'blue2';
+      highlightSpanEl.textContent = highlightedText;
+      highlightOutterSpanEl.appendChild(highlightSpanEl);
+      highlightBoldEl.appendChild(highlightOutterSpanEl);
+      codeEl.replaceWith(highlightBoldEl);
+    }
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
@@ -331,6 +383,7 @@ export function decorateMain(main) {
   decorateExternalLinks(main);
   // decorate external images
   decorateExternalImages(main);
+  decorateTextHighlights(main);
 }
 
 /**

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -358,8 +358,6 @@ function decorateTextHighlights(main) {
   });
 }
 
-
-
 /**
  * Decorates the main element.
  * @param {Element} main The main element

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -209,7 +209,7 @@ function isExternalImage(element) {
   return /https:\/\/www\.cmegroup\.com\/content\/dam\/|delivery-p\d+-e\d+\.adobeaemcloud\.com/.test(element.getAttribute('href'));
 }
 
-/*
+/**
   * Decorates external images with a picture element
   * @param {Element} ele The element
   * @private
@@ -243,6 +243,79 @@ function decorateExternalImages(ele) {
       extImage.parentNode.replaceChild(extPicture, extImage);
     }
   });
+}
+
+/**
+ * Creates and manages a simple lightbox for images
+ */
+async function createSimpleLightbox() {
+  const images = document.querySelectorAll('img[data-lightbox]');
+
+  images.forEach((img) => {
+    img.addEventListener('click', async (e) => {
+      e.preventDefault();
+
+      // eslint-disable-next-line import/no-cycle
+      const { createModal } = await import('../blocks/modal/modal.js');
+
+      const imageElement = document.createElement('img');
+      imageElement.src = img.dataset.lightbox;
+      imageElement.alt = img.alt || '';
+      imageElement.className = 'lightbox-image-display';
+
+      try {
+        const modal = await createModal([imageElement]);
+        const dialog = modal.block.querySelector('dialog');
+        if (dialog) {
+          dialog.classList.add('lightbox-modal');
+          modal.showModal();
+        }
+      } catch (error) {
+        // Lightbox modal creation failed, continue without lightbox functionality
+      }
+    });
+  });
+}
+
+/**
+ * Decorates images with lightbox functionality
+ * @param {Element} main The main element
+ */
+function decorateLightboxImages(main) {
+  const pictures = main.querySelectorAll('picture');
+
+  pictures.forEach((picture) => {
+    // Only process pictures that are wrapped in <strong> tags
+    const strongParent = picture.closest('strong');
+    if (!strongParent) return;
+
+    const img = picture.querySelector('img');
+    if (!img) return;
+
+    const source = picture.querySelector('source') || img;
+    const srcset = source.getAttribute('srcset') || source.getAttribute('src');
+    if (!srcset) return;
+
+    const imageUrl = srcset.split(',')[0].split(' ')[0];
+
+    // Create lightbox structure
+    const wrapper = document.createElement('div');
+    wrapper.className = 'lightbox-container';
+
+    img.setAttribute('data-lightbox', imageUrl);
+    img.classList.add('lightbox-image');
+
+    const icon = document.createElement('span');
+    icon.className = 'lightbox-expand-icon';
+    icon.setAttribute('aria-hidden', 'true');
+
+    // Wrap the picture element
+    picture.parentNode.insertBefore(wrapper, picture);
+    wrapper.appendChild(picture);
+    wrapper.appendChild(icon);
+  });
+
+  createSimpleLightbox();
 }
 
 /**
@@ -304,6 +377,7 @@ export function decorateMain(main) {
   decorateExternalLinks(main);
   // decorate external images
   decorateExternalImages(main);
+  decorateLightboxImages(main); // decorate-lightbox the bolded pictures of decorateExternalImages
   decorateTextHighlights(main);
 }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -336,9 +336,9 @@ function decorateExternalImages(ele) {
  * After:
  * <p>
  *   ...other text
- *   <b><span class="bg-green"><span class="blue2">
+ *   <code class="bg-green highlighted-text">
  *     PLACEHOLDER -> Text the content author highlighted here.
- *   </span></span></b>
+ *   </code>
  *   ... other text
  * </p>
  *
@@ -353,19 +353,12 @@ function decorateTextHighlights(main) {
     const highlightColor = sectionDiv ? sectionDiv.getAttribute('data-text-highlight') : null;
 
     if (highlightColor) {
-      const highlightedText = codeEl.textContent.trim();
-      const highlightBoldEl = document.createElement('b');
-      const highlightOutterSpanEl = document.createElement('span');
-      highlightOutterSpanEl.className = highlightColor;
-      const highlightSpanEl = document.createElement('span');
-      highlightSpanEl.className = 'blue2';
-      highlightSpanEl.textContent = highlightedText;
-      highlightOutterSpanEl.appendChild(highlightSpanEl);
-      highlightBoldEl.appendChild(highlightOutterSpanEl);
-      codeEl.replaceWith(highlightBoldEl);
+      codeEl.classList.add(highlightColor, 'highlighted-text');
     }
   });
 }
+
+
 
 /**
  * Decorates the main element.

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -687,7 +687,7 @@ main .section .layout > div {
   0% {
     transform: rotate(0deg);
   }
-  
+
   100% {
     transform: rotate(360deg);
   }
@@ -871,6 +871,122 @@ body.loading::before {
 .bg-green {
     background-color: var(--green);
 }
+
+/* Lightbox Styles */
+.lightbox-container {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+}
+
+.lightbox-image {
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.lightbox-expand-icon {
+  position: absolute;
+  top: 1.75rem;
+  right: 1.75rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: rgb(255 255 255 / 85%);
+  color: var(--blue4);
+  border-radius: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--cme-group-icons);
+  font-size: 0.875rem;
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 20%);
+}
+
+.lightbox-expand-icon::before {
+  content: var(--icon-expand-secondary);
+}
+
+/* Lightbox Modal Styles */
+.modal dialog.lightbox-modal {
+  width: fit-content;
+  height: fit-content;
+  max-width: 90vw;
+  max-height: 90vh;
+  padding: 0.5rem;
+  border: 1px solid rgb(var(--gray8) / 20%);
+  border-radius: 0.25rem;
+}
+
+.lightbox-image-display {
+  max-width: 85vw;
+  max-height: 85vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 0.25rem;
+  display: block;
+}
+
+/* Lightbox close button styles */
+.modal dialog.lightbox-modal .close-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  margin: 0;
+  border: none !important;
+  border-radius: 0;
+  padding: 0;
+  background-color: transparent;
+  color: #000;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: none !important;
+  outline: none !important;
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal dialog.lightbox-modal .close-button:hover,
+.modal dialog.lightbox-modal .close-button:focus,
+.modal dialog.lightbox-modal .close-button:active {
+  border: none !important;
+  outline: none !important;
+  box-shadow: none !important;
+  background-color: transparent !important;
+}
+
+.modal dialog.lightbox-modal .close-button::before {
+  content: '×';
+  font-family: inherit;
+}
+
+/* Responsive styles */
+@media (width <= 992px) {
+  .lightbox-expand-icon {
+    top: 1rem;
+    right: 1rem;
+    width: 1.875rem;
+    height: 1.875rem;
+    font-size: 0.75rem;
+  }
+}
+
+@media (width <= 576px) {
+  .modal dialog.lightbox-modal {
+    padding: 0.25rem;
+    max-width: 95vw;
+    max-height: 85vh;
+  }
+
+  .lightbox-image-display {
+    max-width: 90vw;
+    max-height: 75vh;
+  }}
 
 .highlighted-text {
     font-weight: bold;

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -871,3 +871,8 @@ body.loading::before {
 .bg-green {
     background-color: var(--green);
 }
+
+.highlighted-text {
+    font-weight: bold;
+    color: var(--blue2);
+  }


### PR DESCRIPTION
Fix #236 

Add text highlighting support.
Author highlights text via "inline text"
Author choose highlight bg style via section metadata property "text-highlight"
- New color highlights can be added in the 'options' sheet under https://da.live/sheet#/cmegroup/www/eds-config/sidekick/blocks

Supported via autoblocking decoration

Test URLs:

Before: https://main--www--cmegroup.aem.page/drafts/john/issue-236-text-highlight
After: https://issue236-text-highlighting--www--cmegroup.aem.page/drafts/john/issue-236-text-highlight
