### PR TITLE
Issue215 Hide course elements via query params

### DIFF
--- a/aemedge/blocks/dynamic/course-nav/course-nav.js
+++ b/aemedge/blocks/dynamic/course-nav/course-nav.js
@@ -238,8 +238,13 @@ async function init(main, courseData) {
 }
 
 export default async function createCourseNav(main) {
+  // Disable if not an allowed template
   const template = getMetadata('template');
   if (!['course', 'lesson'].includes(template.toLowerCase())) return;
+
+  // Disable if hideCourseNav query parameter is set
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('hideCourseNav') === 'y') return;
 
   //  courseData change event
   store.subscribe(({ courseData }) => courseData, (courseData) => {


### PR DESCRIPTION
Fix #215
Hide course nav if ?hideCourseNav=n

Test URLs:

Before: https://main--www--cmegroup.aem.page/education/courses/basic-principles-of-micro-wti-crude-oil-futures
After: https://issue215-hideCourseElements-withQueryParams--www--cmegroup.aem.page/education/courses/basic-principles-of-micro-wti-crude-oil-futures?hideCourseNav=y
