### PR TITLE
Issue215 hide course elements with query params

### DIFF
--- a/aemedge/blocks/dynamic/course-nav/course-nav.js
+++ b/aemedge/blocks/dynamic/course-nav/course-nav.js
@@ -1,6 +1,7 @@
 import { getMetadata, loadCSS } from '../../../scripts/aem.js';
 import { createElement, i18n } from '../../../scripts/utils.js';
 import { store } from '../../../scripts/store/store.js';
+import {  isFeatureToggled } from '../../../scripts/utils.js';
 
 function getTotalLessonsCount(courseData) {
   return courseData.hasChapters
@@ -243,8 +244,7 @@ export default async function createCourseNav(main) {
   if (!['course', 'lesson'].includes(template.toLowerCase())) return;
 
   // Disable if hideCourseNav query parameter is set
-  const urlParams = new URLSearchParams(window.location.search);
-  if (urlParams.get('hideCourseNav') === 'y') return;
+  if (isFeatureToggled('hideCourseNav')) return;
 
   //  courseData change event
   store.subscribe(({ courseData }) => courseData, (courseData) => {

--- a/aemedge/blocks/dynamic/course-nav/course-nav.js
+++ b/aemedge/blocks/dynamic/course-nav/course-nav.js
@@ -238,8 +238,13 @@ async function init(main, courseData) {
 }
 
 export default async function createCourseNav(main) {
+  // Disable if not an allowed template
   const template = getMetadata('template');
   if (!['course', 'lesson'].includes(template.toLowerCase())) return;
+
+  // Disable if hideCourseNav query parameter is set
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('hideCourseNav') === 'y') return;
 
   //  courseData change event
   store.subscribe(({ courseData }) => courseData, (courseData) => {

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -476,6 +476,29 @@ function checkDomain(url) {
   return result;
 }
 
+/**
+ * Checks if a feature toggle is enabled via query parameter.
+ *
+ * @param {string} toggleName - The name of the toggle to check
+ * @param {string} expectedValue - The expected value (defaults to 'y')
+ * @returns {boolean} - True if the toggle is enabled, false otherwise
+ *
+ * @example
+ * // Check if course nav should be hidden
+ * if (isFeatureToggled('hideCourseNav')) {
+ *   // Hide course navigation
+ * }
+ *
+ * // Check for custom value
+ * if (isFeatureToggled('debugMode', 'true')) {
+ *   // Enable debug mode
+ * }
+ */
+function isFeatureToggled(toggleName, expectedValue = 'y') {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get(toggleName) === expectedValue;
+}
+
 export {
   createElement,
   getArticleRelatedMetadata,
@@ -496,4 +519,5 @@ export {
   buildSlider,
   getUTCfromDateString,
   generateRandomId,
+  isFeatureToggled,
 };


### PR DESCRIPTION
Fix #215

Hide course nav if ?hideCourseNav=n

Test URLs:

Before: https://main--www--cmegroup.aem.page/education/courses/basic-principles-of-micro-wti-crude-oil-futures
After: https://issue215-hideCourseElements-withQueryParams--www--cmegroup.aem.page/education/courses/basic-principles-of-micro-wti-crude-oil-futures?hideCourseNav=y