### PR TITLE
Fix issue #359: Use moduleTitle for course name to remove redundant '- CME GROUP' suffix

### DIFF
--- a/aemedge/blocks/dynamic/course-nav/course-nav.js
+++ b/aemedge/blocks/dynamic/course-nav/course-nav.js
@@ -190,7 +190,8 @@ async function init(main, courseData) {
   const titleContent = createElement('div', { class: 'course-nav-title-content' });
   // Title section
   const title = createElement('h2', { class: 'course-nav-title' });
-  title.textContent = courseData.title;
+  // Use moduleTitle for course title (Issue #359)
+  title.textContent = courseData.moduleTitle;
   const viewLessons = createElement('span', { class: 'course-nav-view-lessons' });
   const [viewLessonsLabel, lessonsCountLabel] = await Promise.all([
     i18n('View lessons'),

--- a/aemedge/blocks/search/filter-bullets/filter-bullets.css
+++ b/aemedge/blocks/search/filter-bullets/filter-bullets.css
@@ -1,6 +1,6 @@
 .block.search .filter-bullets {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   gap: 1rem;
   padding-top: 1.5rem;
   background-color: var(--white);
@@ -21,7 +21,8 @@
   font-size: .875rem;
   height: max-content;
   line-height: 1.25rem;
-  margin: .4375rem;
+  margin-bottom: .4375rem;
+  /* margin: .4375rem; */
   padding: .3125rem .9375rem;
   white-space: nowrap;
   text-transform: none;
@@ -41,4 +42,10 @@
   font-size: 1.5625rem;
   line-height: .875rem;
   content: "×";
+}
+
+@media (width >= 768px) {
+  .block.search .filter-bullets {
+    flex-direction: row;
+  }
 }

--- a/aemedge/blocks/search/filter-bullets/filter-bullets.css
+++ b/aemedge/blocks/search/filter-bullets/filter-bullets.css
@@ -22,7 +22,6 @@
   height: max-content;
   line-height: 1.25rem;
   margin-bottom: .4375rem;
-  /* margin: .4375rem; */
   padding: .3125rem .9375rem;
   white-space: nowrap;
   text-transform: none;

--- a/aemedge/blocks/search/filter-bullets/filter-bullets.js
+++ b/aemedge/blocks/search/filter-bullets/filter-bullets.js
@@ -45,10 +45,10 @@ const updateFilteringByUI = async (container, onChange) => {
   appliedFilters.forEach(({ filterId, value, labelContent }) => {
     const tag = button({ class: 'filter-tag' }, labelContent);
     tag.onclick = async () => {
-      const cb = document.querySelector(`#${filterId} input[value="${value}"]`);
-      if (cb) {
+      const cbs = document.querySelectorAll(`#${filterId} input[value="${value}"]`);
+      cbs.forEach((cb) => {
         cb.checked = false;
-      }
+      });
       removeAppliedFilter(filterId, value);
       await updateFilteringByUI(container, onChange);
     };

--- a/aemedge/blocks/search/filter.js
+++ b/aemedge/blocks/search/filter.js
@@ -11,6 +11,22 @@ import { addAppliedFilter, clearAllFilters, removeAppliedFilter } from './search
 import { updateFilteringByUI } from './filter-bullets/filter-bullets.js';
 import { searchResults } from './search-results/search-results.js';
 
+const syncDesktopToMobile = (desktopCheckbox, value, filterId) => {
+  // Find corresponding mobile checkbox by value and filterId
+  const mobileCheckbox = document.querySelector(`.mobile-filter-section#${filterId} input[value="${value}"]`);
+  if (mobileCheckbox && mobileCheckbox !== desktopCheckbox) {
+    mobileCheckbox.checked = desktopCheckbox.checked;
+  }
+};
+
+const syncMobileToDesktop = (mobileCheckbox, value, filterId) => {
+  // Find corresponding desktop checkbox by value and filterId
+  const desktopCheckbox = document.querySelector(`#${filterId} input[value="${value}"]`);
+  if (desktopCheckbox && desktopCheckbox !== mobileCheckbox) {
+    desktopCheckbox.checked = mobileCheckbox.checked;
+  }
+};
+
 const createOption = (value, labelText, type, className, filterId, index) => {
   const id = `${type === 'dropdown' ? 'option' : 'item'}-${filterId}-${index}`;
   const wrapper = div({ class: `${type}-option`, id });
@@ -31,6 +47,9 @@ const createOption = (value, labelText, type, className, filterId, index) => {
   const lbl = label({ class: `${type}-label`, for: `${id}-input` }, labelText);
 
   cb.addEventListener('change', async ({ target }) => {
+    // Sync with mobile counterpart
+    syncDesktopToMobile(target, value, filterId);
+
     if (target.checked) {
       addAppliedFilter(filterId, value, labelText);
     } else {
@@ -170,7 +189,7 @@ const createMobileFilterSection = async (filter, filterId, type) => {
   if (type === 'checkbox') {
     // Simple checkbox handling - no taxonomy resolution needed
     const sorted = sortOptions(filter.values, null, filter.order);
-    
+
     sorted.forEach((value, i) => {
       const id = `item-${filterId}-${i}`;
       const optionWrapper = div({ class: 'checkbox-option', id });
@@ -198,6 +217,9 @@ const createMobileFilterSection = async (filter, filterId, type) => {
 
       // Add event listener for checkbox changes
       checkbox.addEventListener('change', async ({ target }) => {
+        // Sync with desktop counterpart
+        syncMobileToDesktop(target, value, filterId);
+
         if (target.checked) {
           addAppliedFilter(filterId, value, value);
         } else {
@@ -272,6 +294,9 @@ const createMobileFilterSection = async (filter, filterId, type) => {
 
       // Add event listener for checkbox changes
       checkbox.addEventListener('change', async ({ target }) => {
+        // Sync with desktop counterpart
+        syncMobileToDesktop(target, path, filterId);
+
         if (target.checked) {
           addAppliedFilter(filterId, path, optionTitle);
         } else {

--- a/aemedge/blocks/search/filter.js
+++ b/aemedge/blocks/search/filter.js
@@ -1,8 +1,13 @@
-import { div, input, label } from '../../scripts/dom-helpers.js';
+import {
+  div,
+  input,
+  label,
+  button,
+} from '../../scripts/dom-helpers.js';
 import { getTaxonomy } from '../../scripts/taxonomy.js';
 import searchConfig from './search-config.js';
 import { i18n } from '../../scripts/utils.js';
-import { addAppliedFilter, removeAppliedFilter } from './search-utils.js';
+import { addAppliedFilter, clearAllFilters, removeAppliedFilter } from './search-utils.js';
 import { updateFilteringByUI } from './filter-bullets/filter-bullets.js';
 import { searchResults } from './search-results/search-results.js';
 
@@ -141,12 +146,45 @@ const createCheckbox = (options, labelText, order, filterId) => {
   return wrapper;
 };
 
+const createMobileFilterOverlay = async () => {
+  const overlay = div({ class: 'mobile-filter-overlay' });
+
+  const header = div({ class: 'mobile-filter-header' });
+  const title = div({ class: 'mobile-filter-title' }, await i18n('Filter By'));
+  const closeBtn = button({ class: 'mobile-filter-close' });
+  header.append(title, closeBtn);
+  return overlay;
+};
+
 const createFilters = async () => {
   const wrapper = div({ class: 'filters-wrapper' });
   wrapper.append(div({ class: 'filters-wrapper-title' }, await i18n('Filters')));
 
   const container = div({ class: 'filters' });
   wrapper.append(container);
+
+  const mobileFilterButtons = div({ class: 'mobile-filter-buttons' });
+
+  // Add mobile filter button
+  const mobileFilterBtn = button({ class: 'mobile-filter-button primary' }, await i18n('Filters'));
+  const mobileResetBtn = button({ class: 'mobile-reset-button secondary' }, await i18n('Reset'));
+  mobileFilterButtons.append(mobileResetBtn, mobileFilterBtn);
+
+  mobileResetBtn.onclick = async (e) => {
+    e.preventDefault();
+    clearAllFilters();
+    await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResults);
+  };
+
+  // Create and append mobile filter overlay
+  const mobileFilterOverlay = await createMobileFilterOverlay();
+  wrapper.append(mobileFilterButtons, mobileFilterOverlay);
+
+  // Handle mobile filter button click
+  mobileFilterBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    mobileFilterOverlay.classList.add('visible');
+  });
 
   const controls = await Promise.all(
     searchConfig.filters.map((filter, i) => {

--- a/aemedge/blocks/search/filter.js
+++ b/aemedge/blocks/search/filter.js
@@ -11,51 +11,75 @@ import { addAppliedFilter, clearAllFilters, removeAppliedFilter } from './search
 import { updateFilteringByUI } from './filter-bullets/filter-bullets.js';
 import { searchResults } from './search-results/search-results.js';
 
-const syncDesktopToMobile = (desktopCheckbox, value, filterId) => {
-  // Find corresponding mobile checkbox by value and filterId
-  const mobileCheckbox = document.querySelector(`.mobile-filter-section#${filterId} input[value="${value}"]`);
-  if (mobileCheckbox && mobileCheckbox !== desktopCheckbox) {
-    mobileCheckbox.checked = desktopCheckbox.checked;
+/**
+ * Sync checkboxes
+ * @param {HTMLElement} sourceCheckbox
+ * @param {string} value
+ * @param {string} filterId
+ */
+const syncCheckboxes = (sourceCheckbox, value, filterId) => {
+  const isMobile = !!sourceCheckbox.closest('.mobile-filter-overlay');
+  const selector = isMobile
+    ? `#${filterId} input[value="${value}"]`
+    : `.mobile-filter-section#${filterId} input[value="${value}"]`;
+
+  const targetCheckbox = document.querySelector(selector);
+  if (targetCheckbox && targetCheckbox !== sourceCheckbox) {
+    targetCheckbox.checked = sourceCheckbox.checked;
   }
 };
 
-const syncMobileToDesktop = (mobileCheckbox, value, filterId) => {
-  // Find corresponding desktop checkbox by value and filterId
-  const desktopCheckbox = document.querySelector(`#${filterId} input[value="${value}"]`);
-  if (desktopCheckbox && desktopCheckbox !== mobileCheckbox) {
-    desktopCheckbox.checked = mobileCheckbox.checked;
-  }
-};
+/**
+ * Create filter option
+ * @param {Object} options
+ * @param {string} options.value
+ * @param {string} options.labelText
+ * @param {string} options.type
+ * @param {string} options.className
+ * @param {string} options.filterId
+ * @param {number} options.index
+ * @param {boolean} isMobile
+ * @returns {HTMLElement}
+ */
+const createFilterOption = (
+  {
+    value, labelText, type, className, filterId, index,
+  },
+  isMobile = false,
+) => {
+  const idPrefix = isMobile ? 'mobile-' : '';
+  const optionType = type === 'dropdown' ? 'option' : 'item';
+  const id = `${idPrefix}${optionType}-${filterId}-${index}`;
 
-const createOption = (value, labelText, type, className, filterId, index) => {
-  const id = `${type === 'dropdown' ? 'option' : 'item'}-${filterId}-${index}`;
-  const wrapper = div({ class: `${type}-option`, id });
+  const wrapperClass = type === 'dropdown' ? 'dropdown-option' : 'checkbox-option';
+  const wrapper = div({ class: wrapperClass, id });
 
-  // Check if this option is already applied
   const isApplied = searchConfig.appliedFilters.some(
     (appliedFilter) => appliedFilter.value === value,
   );
 
   const cb = input({
-    type: 'checkbox', class: className, value, id: `${id}-input`,
+    type: 'checkbox',
+    class: className,
+    value,
+    id: `${id}-input`,
   });
+  if (isApplied) cb.checked = true;
 
-  if (isApplied) {
-    cb.checked = true;
-  }
-
-  const lbl = label({ class: `${type}-label`, for: `${id}-input` }, labelText);
+  const lbl = label({ class: `${type === 'dropdown' ? 'dropdown-label' : 'checkbox-label'}`, for: `${id}-input` }, labelText);
 
   cb.addEventListener('change', async ({ target }) => {
-    // Sync with mobile counterpart
-    syncDesktopToMobile(target, value, filterId);
+    syncCheckboxes(target, value, filterId);
 
     if (target.checked) {
       addAppliedFilter(filterId, value, labelText);
     } else {
       removeAppliedFilter(filterId, value, labelText);
     }
-    await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResults);
+
+    if (!isMobile) {
+      await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResults);
+    }
   });
 
   wrapper.addEventListener('click', (e) => {
@@ -105,6 +129,14 @@ const resolveTaxonomyPath = (path, taxonomy) => {
   return { node: current, isStar };
 };
 
+/**
+ * Create dropdown
+ * @param {Array} options
+ * @param {string} labelText
+ * @param {string} order
+ * @param {string} filterId
+ * @returns {Promise<HTMLElement>}
+ */
 const createDropdown = async (options, labelText, order, filterId) => {
   const dropdown = div({ class: 'dropdown', id: filterId });
   const toggle = div({ class: 'dropdown-toggle' }, labelText);
@@ -135,7 +167,11 @@ const createDropdown = async (options, labelText, order, filterId) => {
 
   const sorted = sortOptions([...resultMap.values()], 'title', order);
   sorted
-    .forEach(({ path, title }, i) => menu.appendChild(createOption(path, title, 'dropdown', 'dropdown-option-checkbox', filterId, i)));
+    .forEach(({ path, title }, i) => menu.appendChild(
+      createFilterOption({
+        value: path, labelText: title, type: 'dropdown', className: 'dropdown-option-checkbox', filterId, index: i,
+      }),
+    ));
 
   toggle.addEventListener('click', () => {
     menu.classList.toggle('visible');
@@ -163,6 +199,14 @@ const createDropdown = async (options, labelText, order, filterId) => {
   return dropdown;
 };
 
+/**
+ * Create checkbox
+ * @param {Array} options
+ * @param {string} labelText
+ * @param {string} order
+ * @param {string} filterId
+ * @returns {HTMLElement}
+ */
 const createCheckbox = (options, labelText, order, filterId) => {
   const wrapper = div({ class: 'checkbox', id: filterId });
   wrapper.append(label({ class: 'checkbox-label' }, labelText));
@@ -171,11 +215,22 @@ const createCheckbox = (options, labelText, order, filterId) => {
   wrapper.append(container);
 
   sortOptions(options, null, order)
-    .forEach((opt, i) => container.appendChild(createOption(opt, opt, 'checkbox', 'checkbox-input', filterId, i)));
+    .forEach((opt, i) => container.appendChild(
+      createFilterOption({
+        value: opt, labelText: opt, type: 'checkbox', className: 'checkbox-input', filterId, index: i,
+      }),
+    ));
 
   return wrapper;
 };
 
+/**
+ * Create mobile filter section
+ * @param {Object} filter
+ * @param {string} filterId
+ * @param {string} type
+ * @returns {Promise<HTMLElement>}
+ */
 const createMobileFilterSection = async (filter, filterId, type) => {
   const section = div({ class: 'mobile-filter-section', id: filterId });
   const header = div({ class: 'mobile-filter-section-header' });
@@ -191,52 +246,14 @@ const createMobileFilterSection = async (filter, filterId, type) => {
     const sorted = sortOptions(filter.values, null, filter.order);
 
     sorted.forEach((value, i) => {
-      const id = `item-${filterId}-${i}`;
-      const optionWrapper = div({ class: 'checkbox-option', id });
-
-      // Check if this option is already applied
-      const isApplied = searchConfig.appliedFilters.some(
-        (appliedFilter) => appliedFilter.value === value,
-      );
-
-      const checkbox = input({
-        type: 'checkbox',
-        class: 'checkbox-input',
+      content.appendChild(createFilterOption({
         value,
-        id: `${id}-input`,
-      });
-
-      if (isApplied) {
-        checkbox.checked = true;
-      }
-
-      const labelEl = document.createElement('label');
-      labelEl.setAttribute('for', `${id}-input`);
-      labelEl.className = 'checkbox-label';
-      labelEl.textContent = value;
-
-      // Add event listener for checkbox changes
-      checkbox.addEventListener('change', async ({ target }) => {
-        // Sync with desktop counterpart
-        syncMobileToDesktop(target, value, filterId);
-
-        if (target.checked) {
-          addAppliedFilter(filterId, value, value);
-        } else {
-          removeAppliedFilter(filterId, value, value);
-        }
-      });
-
-      optionWrapper.addEventListener('click', (e) => {
-        if (e.target !== checkbox) {
-          e.preventDefault();
-          checkbox.checked = !checkbox.checked;
-          checkbox.dispatchEvent(new Event('change'));
-        }
-      });
-
-      optionWrapper.append(checkbox, labelEl);
-      content.appendChild(optionWrapper);
+        labelText: value,
+        type: 'checkbox',
+        className: 'checkbox-input',
+        filterId,
+        index: i,
+      }, true));
     });
   } else {
     // Dropdown handling with taxonomy resolution (existing code)
@@ -268,52 +285,14 @@ const createMobileFilterSection = async (filter, filterId, type) => {
     const sorted = sortOptions([...resultMap.values()], 'title', filter.order);
 
     sorted.forEach(({ path, title: optionTitle }, i) => {
-      const id = `option-${filterId}-${i}`;
-      const optionWrapper = div({ class: 'dropdown-option', id });
-
-      // Check if this option is already applied
-      const isApplied = searchConfig.appliedFilters.some(
-        (appliedFilter) => appliedFilter.value === path,
-      );
-
-      const checkbox = input({
-        type: 'checkbox',
-        class: 'dropdown-option-checkbox',
+      content.appendChild(createFilterOption({
         value: path,
-        id: `${id}-input`,
-      });
-
-      if (isApplied) {
-        checkbox.checked = true;
-      }
-
-      const labelEl = document.createElement('label');
-      labelEl.setAttribute('for', `${id}-input`);
-      labelEl.className = 'dropdown-label';
-      labelEl.textContent = optionTitle;
-
-      // Add event listener for checkbox changes
-      checkbox.addEventListener('change', async ({ target }) => {
-        // Sync with desktop counterpart
-        syncMobileToDesktop(target, path, filterId);
-
-        if (target.checked) {
-          addAppliedFilter(filterId, path, optionTitle);
-        } else {
-          removeAppliedFilter(filterId, path, optionTitle);
-        }
-      });
-
-      optionWrapper.addEventListener('click', (e) => {
-        if (e.target !== checkbox) {
-          e.preventDefault();
-          checkbox.checked = !checkbox.checked;
-          checkbox.dispatchEvent(new Event('change'));
-        }
-      });
-
-      optionWrapper.append(checkbox, labelEl);
-      content.appendChild(optionWrapper);
+        labelText: optionTitle,
+        type: 'dropdown',
+        className: 'dropdown-option-checkbox',
+        filterId,
+        index: i,
+      }, true));
     });
   }
 
@@ -340,6 +319,9 @@ const createMobileFilterSection = async (filter, filterId, type) => {
   return section;
 };
 
+/**
+ * Update mobile filter checkboxes
+ */
 const updateMobileFilterCheckboxes = () => {
   // Sync mobile checkboxes with applied filters
   document.querySelectorAll('.mobile-filter-checkbox').forEach((checkbox) => {
@@ -350,6 +332,10 @@ const updateMobileFilterCheckboxes = () => {
   });
 };
 
+/**
+ * Create mobile filter overlay
+ * @returns {Promise<HTMLElement>}
+ */
 const createMobileFilterOverlay = async () => {
   const overlay = div({ class: 'mobile-filter-overlay' });
 
@@ -367,9 +353,6 @@ const createMobileFilterOverlay = async () => {
     searchConfig.filters.map((filter, i) => {
       const id = `${filter.type}-${i}`;
       return createMobileFilterSection(filter, id, filter.type);
-      // return filter.type === 'dropdown'
-      //   ? createDropdown(filter.values, filter.name, filter.order, id)
-      //   : Promise.resolve(createCheckbox(filter.values, filter.name, filter.order, id));
     }),
   );
 
@@ -416,7 +399,7 @@ const createMobileFilterOverlay = async () => {
 
 /**
  * Create desktop filters
- * @returns
+ * @returns {Promise<HTMLElement>}
  */
 const createFilters = async () => {
   const wrapper = div({ class: 'filters-wrapper' });
@@ -461,6 +444,13 @@ const createFilters = async () => {
   return wrapper;
 };
 
+/**
+ * Manage filters
+ * @param {string} key
+ * @param {HTMLElement} block
+ * @param {number} index
+ * @returns {Promise<HTMLElement>}
+ */
 const manageFilters = async (key, block, index) => {
   let current = null;
 
@@ -488,6 +478,13 @@ const manageFilters = async (key, block, index) => {
   return tempFilters;
 };
 
+/**
+ * Template filtering
+ * @param {string} key
+ * @param {HTMLElement} block
+ * @param {number} index
+ * @returns {Promise<HTMLElement>}
+ */
 const templateFiltering = (key, block, index) => {
   for (let i = index; i < block.children.length; i += 1) {
     const child = block.children[i];

--- a/aemedge/blocks/search/filter.js
+++ b/aemedge/blocks/search/filter.js
@@ -364,12 +364,27 @@ const createMobileFilterOverlay = async () => {
   footer.appendChild(applyBtn);
 
   // Close button functionality
-  closeBtn.addEventListener('click', () => {
+  closeBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    // remove all other expansion false
+    const expandedSections = document.querySelectorAll('.mobile-filter-section.expanded');
+    expandedSections.forEach((x) => {
+      x.querySelector('.mobile-filter-section-toggle').setAttribute('aria-expanded', 'false');
+      x.querySelector('.mobile-filter-section-content').classList.remove('expanded');
+      x.classList.remove('expanded');
+    });
     overlay.classList.remove('visible');
   });
 
   // Apply button functionality
-  applyBtn.addEventListener('click', async () => {
+  applyBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    const expandedSections = document.querySelectorAll('.mobile-filter-section.expanded');
+    expandedSections.forEach((x) => {
+      x.querySelector('.mobile-filter-section-toggle').setAttribute('aria-expanded', 'false');
+      x.querySelector('.mobile-filter-section-content').classList.remove('expanded');
+      x.classList.remove('expanded');
+    });
     overlay.classList.remove('visible');
     await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResults);
   });

--- a/aemedge/blocks/search/filter.js
+++ b/aemedge/blocks/search/filter.js
@@ -14,9 +14,20 @@ import { searchResults } from './search-results/search-results.js';
 const createOption = (value, labelText, type, className, filterId, index) => {
   const id = `${type === 'dropdown' ? 'option' : 'item'}-${filterId}-${index}`;
   const wrapper = div({ class: `${type}-option`, id });
+
+  // Check if this option is already applied
+  const isApplied = searchConfig.appliedFilters.some(
+    (appliedFilter) => appliedFilter.value === value,
+  );
+
   const cb = input({
     type: 'checkbox', class: className, value, id: `${id}-input`,
   });
+
+  if (isApplied) {
+    cb.checked = true;
+  }
+
   const lbl = label({ class: `${type}-label`, for: `${id}-input` }, labelText);
 
   cb.addEventListener('change', async ({ target }) => {
@@ -147,7 +158,6 @@ const createCheckbox = (options, labelText, order, filterId) => {
 };
 
 const createMobileFilterSection = async (filter, filterId, type) => {
-  console.log(1111, filter, filterId, type);
   const section = div({ class: 'mobile-filter-section', id: filterId });
   const header = div({ class: 'mobile-filter-section-header' });
   const sectionTitle = div({ class: 'mobile-filter-section-title' }, filter.name.toUpperCase());
@@ -155,67 +165,132 @@ const createMobileFilterSection = async (filter, filterId, type) => {
   header.append(sectionTitle, toggle);
 
   const content = div({ class: 'mobile-filter-section-content' });
-  const taxonomy = await getTaxonomy('tags');
-  const resultMap = new Map();
-  const excluded = new Set();
 
-  // Handle star options (similar to existing dropdown logic)
-  filter.values.forEach((opt) => {
-    if (opt.endsWith('--star')) excluded.add(opt.replace('--star', ''));
-    excluded.add(opt);
-  });
+  // Handle different filter types
+  if (type === 'checkbox') {
+    // Simple checkbox handling - no taxonomy resolution needed
+    const sorted = sortOptions(filter.values, null, filter.order);
+    
+    sorted.forEach((value, i) => {
+      const id = `item-${filterId}-${i}`;
+      const optionWrapper = div({ class: 'checkbox-option', id });
 
-  filter.values.forEach((opt) => {
-    const resolved = resolveTaxonomyPath(opt, taxonomy);
-    if (!resolved) return;
+      // Check if this option is already applied
+      const isApplied = searchConfig.appliedFilters.some(
+        (appliedFilter) => appliedFilter.value === value,
+      );
 
-    const { node, isStar } = resolved;
-    if (!resultMap.has(opt)) resultMap.set(opt, { path: opt, title: node.title || opt });
-
-    if (isStar) {
-      const subOptions = recursiveOptionsGet(node, [], excluded);
-      subOptions.forEach((o) => {
-        if (!resultMap.has(o.path)) resultMap.set(o.path, { path: o.path, title: o.label });
+      const checkbox = input({
+        type: 'checkbox',
+        class: 'checkbox-input',
+        value,
+        id: `${id}-input`,
       });
-    }
-  });
 
-  const sorted = sortOptions([...resultMap.values()], 'title', filter.order);
+      if (isApplied) {
+        checkbox.checked = true;
+      }
 
-  sorted.forEach(({ path, title: optionTitle }, i) => {
-    const id = `${type === 'dropdown' ? 'option' : 'item'}-${filterId}-${i}`;
-    const optionWrapper = div({ class: `${type}-option`, id });
-    const checkbox = input({
-      type: 'checkbox',
-      class: 'dropdown-option-checkbox',
-      value: path,
-      id: `${id}-input`,
+      const labelEl = document.createElement('label');
+      labelEl.setAttribute('for', `${id}-input`);
+      labelEl.className = 'checkbox-label';
+      labelEl.textContent = value;
+
+      // Add event listener for checkbox changes
+      checkbox.addEventListener('change', async ({ target }) => {
+        if (target.checked) {
+          addAppliedFilter(filterId, value, value);
+        } else {
+          removeAppliedFilter(filterId, value, value);
+        }
+      });
+
+      optionWrapper.addEventListener('click', (e) => {
+        if (e.target !== checkbox) {
+          e.preventDefault();
+          checkbox.checked = !checkbox.checked;
+          checkbox.dispatchEvent(new Event('change'));
+        }
+      });
+
+      optionWrapper.append(checkbox, labelEl);
+      content.appendChild(optionWrapper);
     });
-    const labelEl = document.createElement('label');
-    labelEl.setAttribute('for', `${id}-input`);
-    labelEl.className = `${type}-label`;
-    labelEl.textContent = optionTitle;
+  } else {
+    // Dropdown handling with taxonomy resolution (existing code)
+    const taxonomy = await getTaxonomy('tags');
+    const resultMap = new Map();
+    const excluded = new Set();
 
-    // Add event listener for checkbox changes
-    checkbox.addEventListener('change', async ({ target }) => {
-      if (target.checked) {
-        addAppliedFilter(filterId, path, optionTitle);
-      } else {
-        removeAppliedFilter(filterId, path, optionTitle);
+    // Handle star options (similar to existing dropdown logic)
+    filter.values.forEach((opt) => {
+      if (opt.endsWith('--star')) excluded.add(opt.replace('--star', ''));
+      excluded.add(opt);
+    });
+
+    filter.values.forEach((opt) => {
+      const resolved = resolveTaxonomyPath(opt, taxonomy);
+      if (!resolved) return;
+
+      const { node, isStar } = resolved;
+      if (!resultMap.has(opt)) resultMap.set(opt, { path: opt, title: node.title || opt });
+
+      if (isStar) {
+        const subOptions = recursiveOptionsGet(node, [], excluded);
+        subOptions.forEach((o) => {
+          if (!resultMap.has(o.path)) resultMap.set(o.path, { path: o.path, title: o.label });
+        });
       }
     });
 
-    optionWrapper.addEventListener('click', (e) => {
-      if (e.target !== checkbox) {
-        e.preventDefault();
-        checkbox.checked = !checkbox.checked;
-        checkbox.dispatchEvent(new Event('change'));
-      }
-    });
+    const sorted = sortOptions([...resultMap.values()], 'title', filter.order);
 
-    optionWrapper.append(checkbox, labelEl);
-    content.appendChild(optionWrapper);
-  });
+    sorted.forEach(({ path, title: optionTitle }, i) => {
+      const id = `option-${filterId}-${i}`;
+      const optionWrapper = div({ class: 'dropdown-option', id });
+
+      // Check if this option is already applied
+      const isApplied = searchConfig.appliedFilters.some(
+        (appliedFilter) => appliedFilter.value === path,
+      );
+
+      const checkbox = input({
+        type: 'checkbox',
+        class: 'dropdown-option-checkbox',
+        value: path,
+        id: `${id}-input`,
+      });
+
+      if (isApplied) {
+        checkbox.checked = true;
+      }
+
+      const labelEl = document.createElement('label');
+      labelEl.setAttribute('for', `${id}-input`);
+      labelEl.className = 'dropdown-label';
+      labelEl.textContent = optionTitle;
+
+      // Add event listener for checkbox changes
+      checkbox.addEventListener('change', async ({ target }) => {
+        if (target.checked) {
+          addAppliedFilter(filterId, path, optionTitle);
+        } else {
+          removeAppliedFilter(filterId, path, optionTitle);
+        }
+      });
+
+      optionWrapper.addEventListener('click', (e) => {
+        if (e.target !== checkbox) {
+          e.preventDefault();
+          checkbox.checked = !checkbox.checked;
+          checkbox.dispatchEvent(new Event('change'));
+        }
+      });
+
+      optionWrapper.append(checkbox, labelEl);
+      content.appendChild(optionWrapper);
+    });
+  }
 
   // Toggle functionality
   header.addEventListener('click', (e) => {
@@ -266,8 +341,10 @@ const createMobileFilterOverlay = async () => {
   const sections = await Promise.all(
     searchConfig.filters.map((filter, i) => {
       const id = `${filter.type}-${i}`;
-      // console.log(filter, id);
       return createMobileFilterSection(filter, id, filter.type);
+      // return filter.type === 'dropdown'
+      //   ? createDropdown(filter.values, filter.name, filter.order, id)
+      //   : Promise.resolve(createCheckbox(filter.values, filter.name, filter.order, id));
     }),
   );
 

--- a/aemedge/blocks/search/filter.js
+++ b/aemedge/blocks/search/filter.js
@@ -146,16 +146,176 @@ const createCheckbox = (options, labelText, order, filterId) => {
   return wrapper;
 };
 
+const createMobileFilterSection = async (filter, filterId, type) => {
+  console.log(1111, filter, filterId, type);
+  const section = div({ class: 'mobile-filter-section', id: filterId });
+  const header = div({ class: 'mobile-filter-section-header' });
+  const sectionTitle = div({ class: 'mobile-filter-section-title' }, filter.name.toUpperCase());
+  const toggle = button({ class: 'mobile-filter-section-toggle', 'aria-expanded': 'false' });
+  header.append(sectionTitle, toggle);
+
+  const content = div({ class: 'mobile-filter-section-content' });
+  const taxonomy = await getTaxonomy('tags');
+  const resultMap = new Map();
+  const excluded = new Set();
+
+  // Handle star options (similar to existing dropdown logic)
+  filter.values.forEach((opt) => {
+    if (opt.endsWith('--star')) excluded.add(opt.replace('--star', ''));
+    excluded.add(opt);
+  });
+
+  filter.values.forEach((opt) => {
+    const resolved = resolveTaxonomyPath(opt, taxonomy);
+    if (!resolved) return;
+
+    const { node, isStar } = resolved;
+    if (!resultMap.has(opt)) resultMap.set(opt, { path: opt, title: node.title || opt });
+
+    if (isStar) {
+      const subOptions = recursiveOptionsGet(node, [], excluded);
+      subOptions.forEach((o) => {
+        if (!resultMap.has(o.path)) resultMap.set(o.path, { path: o.path, title: o.label });
+      });
+    }
+  });
+
+  const sorted = sortOptions([...resultMap.values()], 'title', filter.order);
+
+  sorted.forEach(({ path, title: optionTitle }, i) => {
+    const id = `${type === 'dropdown' ? 'option' : 'item'}-${filterId}-${i}`;
+    const optionWrapper = div({ class: `${type}-option`, id });
+    const checkbox = input({
+      type: 'checkbox',
+      class: 'dropdown-option-checkbox',
+      value: path,
+      id: `${id}-input`,
+    });
+    const labelEl = document.createElement('label');
+    labelEl.setAttribute('for', `${id}-input`);
+    labelEl.className = `${type}-label`;
+    labelEl.textContent = optionTitle;
+
+    // Add event listener for checkbox changes
+    checkbox.addEventListener('change', async ({ target }) => {
+      if (target.checked) {
+        addAppliedFilter(filterId, path, optionTitle);
+      } else {
+        removeAppliedFilter(filterId, path, optionTitle);
+      }
+    });
+
+    optionWrapper.addEventListener('click', (e) => {
+      if (e.target !== checkbox) {
+        e.preventDefault();
+        checkbox.checked = !checkbox.checked;
+        checkbox.dispatchEvent(new Event('change'));
+      }
+    });
+
+    optionWrapper.append(checkbox, labelEl);
+    content.appendChild(optionWrapper);
+  });
+
+  // Toggle functionality
+  header.addEventListener('click', (e) => {
+    e.preventDefault();
+    // remove all other expansion false
+    const expandedSections = document.querySelectorAll('.mobile-filter-section.expanded');
+    expandedSections.forEach((x) => {
+      if (x.querySelector('.mobile-filter-section-header') !== header) {
+        x.querySelector('.mobile-filter-section-toggle').setAttribute('aria-expanded', 'false');
+        x.querySelector('.mobile-filter-section-content').classList.remove('expanded');
+        x.classList.remove('expanded');
+      }
+    });
+
+    const isExpanded = section.querySelector('.mobile-filter-section-toggle')?.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', !isExpanded);
+    content.classList.toggle('expanded', !isExpanded);
+    section.classList.toggle('expanded', !isExpanded);
+  });
+
+  section.append(header, content);
+  return section;
+};
+
+const updateMobileFilterCheckboxes = () => {
+  // Sync mobile checkboxes with applied filters
+  document.querySelectorAll('.mobile-filter-checkbox').forEach((checkbox) => {
+    const isApplied = searchConfig.appliedFilters.some(
+      (filter) => filter.value === checkbox.value,
+    );
+    checkbox.checked = isApplied;
+  });
+};
+
 const createMobileFilterOverlay = async () => {
   const overlay = div({ class: 'mobile-filter-overlay' });
 
+  // Header
   const header = div({ class: 'mobile-filter-header' });
-  const title = div({ class: 'mobile-filter-title' }, await i18n('Filter By'));
+  const title = div({ class: 'mobile-filter-title' }, 'FILTER BY');
   const closeBtn = button({ class: 'mobile-filter-close' });
-  header.append(title, closeBtn);
+  header.append(closeBtn);
+
+  // Content
+  const content = div({ class: 'mobile-filter-content' }, title);
+
+  // Create sections for each filter
+  const sections = await Promise.all(
+    searchConfig.filters.map((filter, i) => {
+      const id = `${filter.type}-${i}`;
+      // console.log(filter, id);
+      return createMobileFilterSection(filter, id, filter.type);
+    }),
+  );
+
+  sections.forEach((section) => content.appendChild(section));
+
+  // Footer with Apply button
+  const footer = div({ class: 'mobile-filter-footer' });
+  const applyBtn = button({ class: 'mobile-filter-apply' }, 'APPLY');
+  footer.appendChild(applyBtn);
+
+  // Close button functionality
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.remove('visible');
+  });
+
+  // Apply button functionality
+  applyBtn.addEventListener('click', async () => {
+    overlay.classList.remove('visible');
+    await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResults);
+  });
+
+  // Close on overlay background click
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      overlay.classList.remove('visible');
+    }
+  });
+
+  // Update checkboxes when overlay becomes visible
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+        if (overlay.classList.contains('visible')) {
+          updateMobileFilterCheckboxes();
+        }
+      }
+    });
+  });
+  observer.observe(overlay, { attributes: true });
+
+  overlay.append(header, content, footer);
   return overlay;
 };
 
+/**
+ * Create desktop filters
+ * @returns
+ */
 const createFilters = async () => {
   const wrapper = div({ class: 'filters-wrapper' });
   wrapper.append(div({ class: 'filters-wrapper-title' }, await i18n('Filters')));

--- a/aemedge/blocks/search/search-utils.js
+++ b/aemedge/blocks/search/search-utils.js
@@ -101,18 +101,21 @@ const populateFromURL = () => {
 
     filters.forEach((filterValue) => {
       // Find the corresponding checkbox
-      const checkbox = document.querySelector(`.dropdown-option-checkbox[value$="/${filterValue}"],
+      const checkboxboxes = document.querySelectorAll(`.dropdown-option-checkbox[value$="/${filterValue}"],
         .dropdown-option-checkbox[value="${filterValue}"], .checkbox-input[value$="/${filterValue}"],
         .checkbox-input[value="${filterValue}"]`);
-      if (checkbox) {
-        checkbox.checked = true;
-        // Add to applied filters
-        const filterId = checkbox.closest('.dropdown')?.id || checkbox.closest('.checkbox')?.id || '';
-        const labelContent = checkbox.closest('.dropdown')?.querySelector('.dropdown-option-label')?.textContent
-          || checkbox.nextElementSibling?.textContent;
-        if (filterId) {
-          addAppliedFilter(filterId, checkbox.value, labelContent);
-        }
+
+      if (checkboxboxes?.length) {
+        checkboxboxes.forEach((checkbox) => {
+          checkbox.checked = true;
+          // Add to applied filters
+          const filterId = checkbox.closest('.dropdown')?.id || checkbox.closest('.checkbox')?.id || '';
+          const labelContent = checkbox.closest('.dropdown')?.querySelector('.dropdown-option-label')?.textContent
+            || checkbox.nextElementSibling?.textContent;
+          if (filterId) {
+            addAppliedFilter(filterId, checkbox.value, labelContent);
+          }
+        });
       }
     });
   }

--- a/aemedge/blocks/search/search.css
+++ b/aemedge/blocks/search/search.css
@@ -268,6 +268,10 @@
   text-transform: uppercase;
 }
 
+.block.search .checkbox-option {
+  display: flex;
+}
+
 .block.search .checkbox-option .checkbox-label {
   font-size: .875rem;
   font-weight: 400;

--- a/aemedge/blocks/search/search.css
+++ b/aemedge/blocks/search/search.css
@@ -42,8 +42,9 @@
 .block.search .search-bar-wrapper .nav-close::before {
   content: var(--icon-menu-close);
   font-weight: normal;
-  font-size: 1.75rem;
+  font-size: 1.1rem;
   color: var(--blue4);
+  margin-left: 0.25rem;
   font-family: var(--cme-group-icons);
 }
 
@@ -315,20 +316,207 @@
 
 .block.search .mobile-filter-overlay.visible {
   display: flex;
+  flex-direction: column;
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   z-index: 100001;
   background-color: var(--gray6);
   overflow-y: auto;
 }
 
+/* Mobile filter overlay header */
+.block.search .mobile-filter-header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: end;
+  padding-top: 1rem;
+}
+
+.block.search .mobile-filter-title {
+  font-size: .625rem;
+  font-weight: 400;
+  letter-spacing: 0.0938rem;
+  text-transform: uppercase;
+  color: var(--gray3);
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.block.search .mobile-filter-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+}
+
+.block.search .mobile-filter-close::after {
+  content: "×";
+  font-size: 1.5rem;
+  color: var(--gray2);
+  font-weight: 300;
+}
+
+/* Mobile filter content */
+.block.search .mobile-filter-content {
+  flex: 1;
+  padding: 1rem 0;
+  padding-top: 0;
+  overflow-y: auto;
+}
+
+/* Mobile filter sections */
+.block.search .mobile-filter-section {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.block.search .mobile-filter-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  cursor: pointer;
+  border-bottom: 1px solid var(--gray4);
+}
+
+.block.search .mobile-filter-section-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.0938rem;
+  text-transform: uppercase;
+  color: var(--gray2);
+}
+
+.block.search .mobile-filter-section-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+}
+
+.block.search .mobile-filter-section-toggle::after {
+  content: "+";
+  font-size: 1.25rem;
+  color: var(--gray2);
+  font-weight: 300;
+  transition: transform 0.2s ease;
+}
+
+.block.search .mobile-filter-section.expanded .mobile-filter-section-toggle::after {
+  content: "−";
+}
+
+.block.search .mobile-filter-section-content {
+  display: none;
+  background-color: var(--gray6);
+}
+
+.block.search .mobile-filter-section-content.expanded {
+  display: block;
+}
+
+/* Mobile filter options */
+.block.search .mobile-filter-option {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--gray4);
+}
+
+.block.search .mobile-filter-option:last-child {
+  /* border-bottom: none; */
+}
+
+.block.search .mobile-filter-checkbox {
+  appearance: none;
+  background-color: var(--white);
+  margin-right: 0.75rem;
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+  border: 1px solid var(--gray4);
+  border-radius: 2px;
+  position: relative;
+}
+
+.block.search .mobile-filter-checkbox:checked {
+  background-color: var(--blue4);
+  border-color: var(--blue4);
+}
+
+.block.search .mobile-filter-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 4px;
+  width: 4px;
+  height: 8px;
+  border: solid var(--white);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.block.search .mobile-filter-label {
+  flex: 1;
+  cursor: pointer;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: var(--gray2);
+}
+
+/* Mobile filter footer */
+.block.search .mobile-filter-footer {
+  border-radius: .25rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.block.search .mobile-filter-apply {
+  width: 100%;
+  background-color: var(--blue4);
+  color: var(--white);
+  border: none;
+  padding: 0.875rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.0938rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  justify-content: center;
+}
+
+.block.search .mobile-filter-apply:hover {
+  background-color: var(--blue3);
+}
+
+.block.search input.search-input::placeholder {
+  font-size: 1.25rem; /* Or your desired smaller size, e.g., 14px */
+}
+
 @media (width >= 768px) {
   .block.search .search-input {
     height: 3rem;
-    font-size: 2.375rem;
+    font-size: 2rem;
+  }
+
+  .block.search .search-bar-wrapper .nav-close::before {
+    font-size: 1.75rem;
+  }
+
+  .block.search input.search-input::placeholder {
+    font-size: 2rem;
   }
 
   .block.search .search-icon::before {

--- a/aemedge/blocks/search/search.css
+++ b/aemedge/blocks/search/search.css
@@ -6,7 +6,7 @@
   background-color: var(--gray6);
   display: flex;
   flex-direction: column;
-  margin-bottom: 4rem;
+  margin-bottom: 2rem;
 }
 
 .block.search .search-bar-wrapper {
@@ -220,7 +220,9 @@
   border-bottom: .1875rem solid var(--white);
   border-right: .1875rem solid var(--white);
   height: .5rem;
-  position: absolute;
+  position: relative;
+  bottom: 0.3rem;
+  /* position: absolute; */
   width: .1rem;
   transform: rotate(45deg);
   content: "";
@@ -273,6 +275,13 @@
   line-height: 1.25rem;
   text-transform: unset;
   cursor: pointer;
+}
+
+.block.search .mobile-filter-overlay .checkbox-option {
+  padding: 8px 12px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
 }
 
 .block.search .checkbox-input {

--- a/aemedge/blocks/search/search.css
+++ b/aemedge/blocks/search/search.css
@@ -222,7 +222,6 @@
   height: .5rem;
   position: relative;
   bottom: 0.3rem;
-  /* position: absolute; */
   width: .1rem;
   transform: rotate(45deg);
   content: "";

--- a/aemedge/blocks/search/search.css
+++ b/aemedge/blocks/search/search.css
@@ -447,10 +447,6 @@
   border-bottom: 1px solid var(--gray4);
 }
 
-.block.search .mobile-filter-option:last-child {
-  /* border-bottom: none; */
-}
-
 .block.search .mobile-filter-checkbox {
   appearance: none;
   background-color: var(--white);
@@ -514,7 +510,7 @@
 }
 
 .block.search input.search-input::placeholder {
-  font-size: 1.25rem; /* Or your desired smaller size, e.g., 14px */
+  font-size: 1.25rem;
 }
 
 @media (width >= 768px) {

--- a/aemedge/blocks/search/search.css
+++ b/aemedge/blocks/search/search.css
@@ -19,8 +19,8 @@
 
 .block.search .search-input {
   border: none;
-  font-size: 2.375rem;
-  height: 4.25rem;
+  font-size: 1rem;
+  height: 2rem;
   outline: none;
   padding-left: 1rem;
   width: 100%;
@@ -54,11 +54,9 @@
   margin-bottom: 1.5rem;
 }
 
-
-
 .block.search .filters-wrapper .filters {
   flex-flow: row wrap;
-  display: flex;
+  display: none;
   align-items: center;
   gap: 2rem;
 }
@@ -84,7 +82,7 @@
 .block.search .search-icon::before {
   content: "";
   font-weight: normal;
-  font-size: 1.75rem;
+  font-size: 1.25rem;
   color: var(--blue4);
 }
 
@@ -97,8 +95,6 @@
   flex-direction: row;
 }
 
-
-
 .block.search .filters-wrapper-title {
   color: var(--gray3);
   font-size: 1rem;
@@ -108,6 +104,7 @@
   margin-right: 1.875rem;
   padding-top: .625rem;
   text-transform: uppercase;
+  display: none;
 }
 
 .block.search .dropdown {
@@ -296,4 +293,69 @@
 
 .block.search .results-wrapper.columns-2 .result-card img {
   display: none;
+}
+
+.block.search .mobile-filter-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.block.search .mobile-filter-buttons button {
+  width: 45%;
+  align-items: center;
+  justify-content: center;
+}
+
+.block.search .mobile-filter-overlay {
+  display: none;
+}
+
+.block.search .mobile-filter-overlay.visible {
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 100001;
+  background-color: var(--gray6);
+  overflow-y: auto;
+}
+
+@media (width >= 768px) {
+  .block.search .search-input {
+    height: 3rem;
+    font-size: 2.375rem;
+  }
+
+  .block.search .search-icon::before {
+    font-size: 1.75rem;
+  }
+
+  .block.search .mobile-filter-button {
+    display: none;
+  }
+
+  .block.search .mobile-filter-buttons {
+    display: none;
+  }
+
+  .block.search .filters-wrapper-title {
+    display: flex;
+  }
+
+  .block.search .filters-wrapper .filters {
+    display: flex;
+  }
+
+  .block.search .mobile-filter-overlay {
+    display: none;
+  }
+
+  .block.search .mobile-filter-overlay.visible {
+    display: none;
+  }
 }

--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -1,4 +1,5 @@
 import { sampleRUM, loadScript } from './aem.js';
+import { getEnvType } from './utils.js';
 import loadSitewidePopups from './popups/popups.js';
 
 // Core Web Vitals RUM collection
@@ -8,9 +9,47 @@ function loadShareThis() {
   loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=644646a57ac381001a304496&product=sticky-share-buttons&source=platform');
 }
 
+async function loadOneTrust() {
+  if (getEnvType() !== 'prod') {
+    return Promise.resolve();
+  }
+
+  const ONETRUST_CONFIG = {
+    stubScript: {
+      url: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+      options: {
+        type: 'text/javascript',
+        charset: 'UTF-8',
+      },
+    },
+    mainScript: {
+      url: 'https://cdn.cookielaw.org/consent/f42915b0-68e5-491a-a7f7-1db0d962ddff/OtAutoBlock.js',
+      options: {
+        type: 'text/javascript',
+        charset: 'UTF-8',
+        'data-domain-script': 'f42915b0-68e5-491a-a7f7-1db0d962ddff',
+      },
+    },
+  };
+
+  try {
+    await loadScript(ONETRUST_CONFIG.stubScript.url, ONETRUST_CONFIG.stubScript.options);
+    await loadScript(ONETRUST_CONFIG.mainScript.url, ONETRUST_CONFIG.mainScript.options);
+    if (!window.OneTrust) {
+      throw new Error('OneTrust failed to initialize');
+    }
+    return Promise.resolve();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('OneTrust loading failed:', error);
+    return Promise.resolve();
+  }
+}
+
 function loadPage() {
   loadSitewidePopups();
   loadShareThis();
+  loadOneTrust();
 }
 
 loadPage();

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -414,6 +414,8 @@ async function loadEager(doc) {
 async function loadLazy(doc) {
   // import('./dataLayerImport.js');
   // dataLayer.handleLoad();
+
+  
   autolinkModals(doc);
 
   const main = doc.querySelector('main');

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -412,8 +412,8 @@ async function loadEager(doc) {
  * @param {Element} doc The container element
  */
 async function loadLazy(doc) {
-  import('./dataLayerImport.js');
-  dataLayer.handleLoad();
+  // import('./dataLayerImport.js');
+  // dataLayer.handleLoad();
   autolinkModals(doc);
 
   const main = doc.querySelector('main');


### PR DESCRIPTION
## Description
This PR fixes issue #359 where course names display with a redundant "- CME GROUP" suffix, even though CME Group branding is already present throughout the site.

## Changes Made
- Modified the course-nav.js file to use `moduleTitle` instead of `title` for course names in the navigation
- This follows the existing pattern in the code where `moduleTitle` is already used for lessons and chapters
- Eliminates the need for regex replacements since `moduleTitle` doesn't contain the redundant suffix

## Testing
- Tested in the local development environment using AEM server 
- Verified the course title displays correctly without the redundant "- CME GROUP" suffix

## Screenshots
Before: Course titles displayed with redundant "- CME GROUP" suffix
After: Course titles display cleanly without the redundant suffix

Droid-assisted PR