### PR TITLE
Fix #376 Add factoid box (blue box with white text) as a card variant

### DIFF
--- a/aemedge/blocks/cards/cards-factoid.css
+++ b/aemedge/blocks/cards/cards-factoid.css
@@ -1,0 +1,37 @@
+/* Factoid card styling - creates a centered dark blue box with white text */
+
+.cards.factoid ul {
+    display: block;
+    justify-content: space-between;
+}
+
+.cards.factoid li {
+    width: 70%;
+    background-color: #071b34;
+    margin: 0 auto 2rem;
+    display: flex;
+    align-items: center;
+}
+
+.cards.factoid li .cards-card-body {
+    width: 100%;
+    color: var(--white);
+    padding: 1.25rem;
+    margin: 0;
+}
+
+.cards.factoid li .cards-card-body p {
+    margin: 0;
+}
+
+@media (width >= 769px) {
+    .cards.factoid li .cards-card-body {
+        padding: 1.875rem;
+    }
+}
+
+@media (width >= 993px) {
+    .cards.factoid ul {
+        display: flex;
+    }
+}

--- a/aemedge/blocks/cards/cards.css
+++ b/aemedge/blocks/cards/cards.css
@@ -11,3 +11,4 @@
 @import url("cards-tiles.css");
 @import url("cards-list-thumbnail-medium.css");
 @import url("cards-upcoming-events.css");
+@import url("cards-factoid.css");


### PR DESCRIPTION
Add factoid box (blue box with white text) as a card variant

Before: https://main--www--cmegroup.aem.page/drafts/john/issue-376-what-is-an-etf
After: https://issue376-factoidCardVariant--www--cmegroup.aem.page/drafts/john/issue-376-what-is-an-etf

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www--cmegroup.aem.live/
- After: https://<branch>--www--cmegroup.aem.live/
