### PR TITLE
Fix #365 Nested bullets are formatted incorrectly

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -262,6 +262,11 @@ blockquote {
     margin-bottom: 0.25em;
 }
 
+/* Remove margin-top from nested ul elements under li */
+li ul {
+    margin-top: 0;
+}
+
 code,
 pre {
     font-size: var(--body-font-size-s);
@@ -333,6 +338,7 @@ ol li,
 ul li {
     margin-bottom: 0.625rem;
 }
+
 
 /* HR Default Styles */
 hr {


### PR DESCRIPTION
FIx : #365  | Nested bullets are formatted incorrectly

Before: https://main--www--cmegroup.aem.page/education/courses/building-a-trade-plan/methodology-behind-your-trade-plan
After: https://issue-365-bulletSeparation--www--cmegroup.aem.page/education/courses/building-a-trade-plan/methodology-behind-your-trade-plan

Part of the problem was with the nexted elements being auto-wrapped in p element which pulled in conflicting styling for what we needed.

This was a DA issue and a feature toggle (html2md.unspreadLists) was added to CME sites to maintain the original markup (not wrap with p element).

This fixed most of the issue. Only a small style override was required to fix the remaining issue.
