### PR TITLE
Reduced axios functions simplifying relative to absolute differences

### DIFF
--- a/aemedge/blocks/brightcove/brightcove.js
+++ b/aemedge/blocks/brightcove/brightcove.js
@@ -1,7 +1,7 @@
 import { readBlockConfig, getMetadata } from '../../scripts/aem.js';
 import {
   setTracking,
-  apiGetAbsolute,
+  apiGet,
   LocalStorageUtil,
   getRandomNumber,
 } from '../../scripts/utils/index.js';
@@ -270,7 +270,7 @@ async function getBrightcovePoster(accountId, videoId) {
   }
   const url = `https://edge.api.brightcove.com/playback/v1/accounts/${accountId}/videos/${videoId}`;
 
-  const response = await apiGetAbsolute(url, {}, {
+  const response = await apiGet(url, {}, {
     Accept: `application/json;pk=${policyKey}`,
   });
 

--- a/aemedge/scripts/course/certificate.js
+++ b/aemedge/scripts/course/certificate.js
@@ -4,7 +4,7 @@ import {
   urlByEnvType,
 } from '../utils.js';
 import {
-  apiPostAbsolute,
+  apiPost,
   getResponseData,
 } from '../utils/index.js';
 import { loadScript, getMetadata } from '../aem.js';
@@ -167,7 +167,7 @@ async function handleDownloadClick(block) {
 async function getShareCertificateData(formData) {
   try {
     const url = `${urlByEnvType()}/services/course-certificate`;
-    const response = await apiPostAbsolute(url, formData);
+    const response = await apiPost(url, formData);
     return getResponseData(response, 'objectId');
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/aemedge/scripts/services/AuthenticationService.js
+++ b/aemedge/scripts/services/AuthenticationService.js
@@ -1,6 +1,6 @@
 import {
-  apiGetAbsolute,
-  apiPostAbsolute,
+  apiGet,
+  apiPost,
   getResponseData,
 } from '../utils/index.js';
 import { getLoginDataUrl } from '../legacy-api.js';
@@ -9,7 +9,7 @@ import { urlByEnvType } from '../utils.js';
 export async function getIsLoggedIn() {
   const isLoggedInService = `${urlByEnvType()}/services/login/validate`;
   try {
-    const response = await apiGetAbsolute(isLoggedInService);
+    const response = await apiGet(isLoggedInService);
     return getResponseData(response);
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -21,7 +21,7 @@ export async function getIsLoggedIn() {
 export async function getLoginData(fromUrl, fromUrlTitle) {
   const url = getLoginDataUrl(fromUrl, fromUrlTitle);
   try {
-    const response = await apiGetAbsolute(url);
+    const response = await apiGet(url);
     return getResponseData(response);
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -34,7 +34,7 @@ export async function getUserInfo(userInfo) {
   const url = `${urlByEnvType()}/CmeWS/mvc/secured/UserAccount/salesforce-userinfo`;
   const { userId, token } = userInfo;
   try {
-    const response = await apiPostAbsolute(url, {
+    const response = await apiPost(url, {
       userId,
       token,
     });

--- a/aemedge/scripts/services/EducationTrackService.js
+++ b/aemedge/scripts/services/EducationTrackService.js
@@ -1,6 +1,6 @@
 import {
-  apiGetAbsolute,
-  apiPostAbsolute,
+  apiGet,
+  apiPost,
   getResponseData,
   isEmpty,
 } from '../utils/index.js';
@@ -86,7 +86,7 @@ async function getStorageProgress(moduleId) {
   const url = `${urlByEnvType()}/services/education-track/public-progress`;
   try {
     const progress = syncStorage.get();
-    const response = await apiPostAbsolute(url, {
+    const response = await apiPost(url, {
       progress,
     });
     const data = getResponseData(response);
@@ -115,7 +115,7 @@ export async function getProgress(moduleId, moduleType) {
   const url = `${urlByEnvType()}/services/education-track/${
     moduleType === 'lesson' ? 'progress-for-lesson' : 'progress-for-course'}/${moduleId}`;
   try {
-    const response = await apiGetAbsolute(url);
+    const response = await apiGet(url);
     const data = getResponseData(response);
     return mapModule(data);
   } catch (e) {
@@ -133,7 +133,7 @@ async function postProgress(
 ) {
   try {
     const url = `${urlByEnvType()}/services/education-track/progress`;
-    const response = await apiPostAbsolute(url, {
+    const response = await apiPost(url, {
       progress,
     });
     return getResponseData(response) || {};

--- a/aemedge/scripts/services/SearchResultsService.js
+++ b/aemedge/scripts/services/SearchResultsService.js
@@ -1,7 +1,6 @@
 import {
   apiGet,
-  apiGetAbsolute,
-  apiPostAbsolute,
+  apiPost,
   getResponseData,
   DataCacheUtil,
 } from '../utils/index.js';
@@ -77,7 +76,7 @@ export async function getPopularSearch() {
   const url = window.globalConfig?.popularSearchUrl
     || `${urlByEnvType()}/services/popular-search`;
   try {
-    const response = await apiGetAbsolute(url);
+    const response = await apiGet(url);
     const data = getResponseData(response, 'data');
     return data.map((item) => {
       const { title } = item;
@@ -102,7 +101,7 @@ export async function getRecentSearch(loginInfo) {
 
   try {
     const loggedSearches = getResponseData(
-      await apiPostAbsolute(`${urlByEnvType()}/CmeWS/mvc/secured/MostRecentSearchedTerm/getByUser`, {
+      await apiPost(`${urlByEnvType()}/CmeWS/mvc/secured/MostRecentSearchedTerm/getByUser`, {
         ...getUserInfo(loginInfo),
       }),
       'data',
@@ -123,7 +122,7 @@ export async function getRecentSearch(loginInfo) {
       )
       .slice(0, 5);
 
-    apiPostAbsolute(
+    apiPost(
       `${urlByEnvType()}/CmeWS/mvc/secured/MostRecentSearchedTerm/fullUpdateByUser`,
       {
         ...getUserInfo(loginInfo),
@@ -147,7 +146,7 @@ export async function updateRecentSearch(
 ) {
   if (isLoggedIn) {
     try {
-      return apiPostAbsolute(
+      return apiPost(
         `${urlByEnvType()}/CmeWS/mvc/secured/MostRecentSearchedTerm/updateByUser`,
         {
           ...getUserInfo(loginInfo),
@@ -195,7 +194,7 @@ export async function getSearchSuggestions(
   limit,
 ) {
   try {
-    const response = await apiGetAbsolute(getSearchSuggestionsUrl(term));
+    const response = await apiGet(getSearchSuggestionsUrl(term));
     const data = getResponseData(response, 'data');
     if (data) {
       return data.slice(0, limit);

--- a/aemedge/scripts/utils/fetch.js
+++ b/aemedge/scripts/utils/fetch.js
@@ -21,18 +21,6 @@ export function apiGet(
   return axiosGet(baseUrl + url, data);
 }
 
-export function apiGetAbsolute(
-  url,
-  params = {},
-  headers = {},
-  // withCache = false,
-) {
-  const baseUrl = window.baseUrl || '';
-  const data = { params, headers };
-  // return axiosGet(baseUrl + makeProtectedUrl(url, withCache), true, data);
-  return axiosGet(baseUrl + url, data, true);
-}
-
 export function apiPost(
   url,
   params = {},
@@ -46,21 +34,6 @@ export function apiPost(
   return axiosPost(baseUrl + url, params, {
     headers,
   });
-}
-
-export function apiPostAbsolute(
-  url,
-  params = {},
-  headers = {},
-  // withCache = false,
-) {
-  const baseUrl = window.baseUrl || '';
-  // return axiosPost(baseUrl + makeProtectedUrl(url, withCache), params, true, {
-  //   headers,
-  // });
-  return axiosPost(baseUrl + url, params, {
-    headers,
-  }, true);
 }
 
 export function getResponseData(

--- a/aemedge/scripts/utils/misc.js
+++ b/aemedge/scripts/utils/misc.js
@@ -31,14 +31,13 @@ export function isEmpty(value) {
   return true; // Default to true for other types (e.g., functions)
 }
 
-export async function axiosGet(url, config = {}, absoluteUrl = false) {
+function isAbsoluteUrl(url) {
+  return /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(url);
+}
+
+export async function axiosGet(url, config = {}) {
   const { params = {}, headers = {} } = config;
-  let urlObj;
-  if (absoluteUrl) {
-    urlObj = new URL(url);
-  } else {
-    urlObj = new URL(window.location.origin + url);
-  }
+  const urlObj = new URL((!isAbsoluteUrl(url) ? window.location.origin : '') + url);
   Object.keys(params).forEach((key) => urlObj.searchParams.append(key, params[key]));
 
   const fetchOptions = {
@@ -80,14 +79,9 @@ export async function axiosGet(url, config = {}, absoluteUrl = false) {
   }
 }
 
-export async function axiosPost(url, data, config = {}, absoluteUrl = false) {
+export async function axiosPost(url, data, config = {}) {
   const { headers = {}, params = {} } = config;
-  let urlObj;
-  if (absoluteUrl) {
-    urlObj = new URL(url);
-  } else {
-    urlObj = new URL(window.location.origin + url);
-  }
+  const urlObj = new URL((!isAbsoluteUrl(url) ? window.location.origin : '') + url);
   Object.keys(params).forEach((key) => urlObj.searchParams.append(key, params[key]));
 
   const fetchOptions = {


### PR DESCRIPTION
This update reduces the api utility functions down to two (from four) simplifying the need to manually use a specific function based on whether the url contains an absolute or relative url. Functions axiosGet and axiosPost will now check the url for a schema.

Fix #452 

Test URLs:
- Before: https://main--www--cmegroup.aem.live/drafts/chamo/economic-calendar
- After: https://fix-event-cal--www--cmegroup.aem.live/drafts/chamo/economic-calendar
