### PR TITLE
Set correct styles for BC video and placeholders

### DIFF
--- a/aemedge/blocks/brightcove/brightcove.css
+++ b/aemedge/blocks/brightcove/brightcove.css
@@ -71,8 +71,6 @@
 
 .brightcove-img-placeholder {
     width: 100%;
-
-    /* min-height: 22.125rem; */
     background-size: cover;
     display: inline-block;
     vertical-align: middle;
@@ -81,7 +79,6 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    aspect-ratio: 16 / 9;
     z-index: 1;
 
     &:hover {
@@ -93,7 +90,16 @@
         }
     }
 
-    &.playlist-right {
+    &.aspect-ratio169 {
+        aspect-ratio: 16 / 9;
+    }
+
+    &.aspect-ratio43 {
+        aspect-ratio: 4 / 3;
+    }
+
+    &.playlist-right-sidekick {
+        min-height: 22.125rem;
         position: relative;
     }
 }

--- a/aemedge/blocks/brightcove/brightcove.js
+++ b/aemedge/blocks/brightcove/brightcove.js
@@ -359,13 +359,13 @@ export default async function decorate(block) {
 
   const playlist = playlistId !== '' && playlistLocation ? playlistLocation : '';
   const dataPlayer = calculateDataPlayerId(aspectRatio, playlist, cc);
-  const videoStyles = calculateStyles(aspectRatio, playlistLocation);
+  const videoStyles = calculateStyles(aspectRatio, playlist);
   const randomNumber = getRandomNumber();
 
   block.innerHTML = `
   <div class='brightcove-player'>
     <div
-      class="brightcove-img-placeholder ${playlistId !== '' && playlistLocation === 'R' ? 'playlist-right' : ''}"
+      class="brightcove-img-placeholder ${videoStyles}"
       style="background-image: url('${videoPoster}')">
       <div class="placeholder-play-btn"></div>
     </div>


### PR DESCRIPTION
Fixed the logic that adds style classes based on the aspectRatio and playlistLocation block configurations.

Fix #455 

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education/courses/building-a-trade-plan
- After: https://issue-455-bc-styles--www--cmegroup.aem.live/education/courses/building-a-trade-plan
