### PR TITLE
Add defaultPlaylistPoster field for BC playlists blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,12 @@ module.exports = {
     'import/extensions': ['error', { js: 'always' }], // require js file extensions in imports
     'linebreak-style': ['error', 'unix'], // enforce unix linebreaks
     'no-param-reassign': [2, { props: false }], // allow modifying properties of param
+    'no-use-before-define': ['error', { // allow use of traditional functions before their definition as they are completely hoisted
+      functions: false,
+      classes: true,
+      variables: true,
+      allowNamedExports: false,
+    }],
   },
   globals: {
     dayjs: 'readonly',

--- a/aemedge/blocks/brightcove/brightcove.js
+++ b/aemedge/blocks/brightcove/brightcove.js
@@ -1,4 +1,5 @@
-import { readBlockConfig, getMetadata } from '../../scripts/aem.js';
+import { getMetadata } from '../../scripts/aem.js';
+import { readBlockConfig } from '../../scripts/utils.js';
 import {
   setTracking,
   LocalStorageUtil,
@@ -265,7 +266,7 @@ function getPosterCache() {
 async function getBrightcovePoster(accountId, videoId) {
   const policyKey = getMetadata('brightcove-policy-key');
 
-  if (!policyKey) {
+  if (!policyKey || !videoId) {
     return '';
   }
   const url = `https://edge.api.brightcove.com/playback/v1/accounts/${accountId}/videos/${videoId}`;
@@ -315,7 +316,7 @@ function changeQualityPosterUrl(posterUrl) {
   return posterUrl.replace(/\d*x\d*(\/match\/image)/g, (match, group1) => `${isDesktop ? '800x400' : '400x225'}${group1}`);
 }
 
-async function getPosterWithCache(block, accountId, videoId) {
+async function getPosterWithCache(accountId, videoId) {
   const cache = getPosterCache();
   let posterUrl = cache[videoId]?.posterUrl || await getBrightcovePoster(accountId, videoId);
 
@@ -360,18 +361,19 @@ export default async function decorate(block) {
     aspectratio: aspectRatio,
     cc,
     language,
+    defaultplaylistposter: defaultPlaylistPoster,
   } = dataBlock;
   const playlist = playlistId !== '' && playlistLocation ? playlistLocation : '';
   const dataPlayer = calculateDataPlayerId(aspectRatio, playlist, cc);
   const videoStyles = calculateStyles(aspectRatio, playlist);
   const randomNumber = getRandomNumber();
 
-  const posterUrl = await getPosterWithCache(block, accountId, videoId);
+  const posterUrl = defaultPlaylistPoster || await getPosterWithCache(accountId, videoId);
 
   block.innerHTML = `
   <div class='brightcove-player'>
     <div class="brightcove-placeholder">
-      <img class="brightcove-img-placeholder ${videoStyles}" src="${posterUrl}" fetchpriority="high" />
+      ${posterUrl ? `<img class="brightcove-img-placeholder ${videoStyles}" src="${posterUrl}" fetchpriority="high" />` : ''}
       <div class="spinner-in-video">
         <div></div>
         <div></div>


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www--cmegroup.aem.live/drafts/gmaye/brightcove
- After: https://bc-video-playlist-poster--www--cmegroup.aem.live/drafts/gmaye/brightcove
