### PR TITLE
Fix# 475 Preserve hide params on links

### DIFF
--- a/aemedge/blocks/dynamic/course-nav/course-nav.js
+++ b/aemedge/blocks/dynamic/course-nav/course-nav.js
@@ -1,5 +1,10 @@
 import { getMetadata, loadCSS } from '../../../scripts/aem.js';
-import { createElement, i18n, isFeatureToggled } from '../../../scripts/utils.js';
+import {
+  createElement,
+  i18n,
+  isFeatureToggled,
+  preserveHideParameters,
+} from '../../../scripts/utils.js';
 import { store } from '../../../scripts/store/store.js';
 
 function getTotalLessonsCount(courseData) {
@@ -218,6 +223,9 @@ async function init(main, courseData) {
 
   nav.append(header, content);
   main.prepend(nav);
+
+  // Apply hide parameters preservation to course navigation links
+  preserveHideParameters(nav);
 
   header.addEventListener('click', (e) => {
     e.stopPropagation();

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -612,6 +612,53 @@ function getCountryCode() {
   return new Intl.Locale(locale)?.region || '';
 }
 
+/**
+ * Preserves hideXXX query parameters for internal links
+ * @param {Element} main The main element
+ */
+function preserveHideParameters(main) {
+  const currentUrl = new URL(window.location.href);
+  const hideParams = new Map();
+
+  // Extract all hideXXX parameters from current URL
+  currentUrl.searchParams.forEach((value, key) => {
+    if (key.startsWith('hide') && value) {
+      hideParams.set(key, value);
+    }
+  });
+
+  // If no hide parameters, nothing to preserve
+  if (hideParams.size === 0) return;
+
+  main.querySelectorAll('a[href]').forEach((link) => {
+    const href = link.getAttribute('href');
+    if (href) {
+      const isInternal = href.startsWith('/') || href.startsWith('#') || href.startsWith('?');
+      const isAnchorOnly = href.startsWith('#');
+
+      // Only process internal links that aren't just anchor links
+      if (isInternal && !isAnchorOnly) {
+        try {
+          const linkUrl = new URL(href, window.location.origin);
+
+          // Add hide parameters that don't already exist
+          hideParams.forEach((value, key) => {
+            if (!linkUrl.searchParams.has(key)) {
+              linkUrl.searchParams.set(key, value);
+            }
+          });
+
+          // Update the href with preserved parameters
+          const newHref = linkUrl.pathname + linkUrl.search + linkUrl.hash;
+          link.setAttribute('href', newHref);
+        } catch (error) {
+          // Skip malformed URLs
+        }
+      }
+    }
+  });
+}
+
 export {
   loadScript,
   createElement,
@@ -638,4 +685,5 @@ export {
   setupDayjsLibs,
   getCdtDate,
   getCountryCode,
+  preserveHideParameters,
 };

--- a/aemedge/templates/course/course.js
+++ b/aemedge/templates/course/course.js
@@ -1,5 +1,5 @@
 import { getCourseData, createCourseBaseTemplate } from '../../scripts/course/course.js';
-import { createElement, i18n } from '../../scripts/utils.js';
+import { createElement, i18n, preserveHideParameters } from '../../scripts/utils.js';
 import { authentication } from '../../scripts/modules/Authentication.js';
 import { store } from '../../scripts/store/store.js';
 import { courseDataChange } from '../../scripts/actions/course.js';
@@ -43,6 +43,11 @@ export default async function courseTemplate() {
     } else {
       await addBeginCourseButton(courseData);
     }
+
+    // Apply hide parameters preservation after course content is loaded
+    const main = document.querySelector('main');
+    preserveHideParameters(main);
+
     //  dispatch courseData event
     store.dispatch(courseDataChange(courseData));
   });

--- a/aemedge/templates/lesson/lesson.js
+++ b/aemedge/templates/lesson/lesson.js
@@ -97,6 +97,10 @@ async function addLateralNavigation(prevHref, nextHref) {
   );
 
   main.appendChild(nav);
+
+  // Apply hide parameters preservation to navigation links
+  const { preserveHideParameters } = await import('../../scripts/utils.js');
+  preserveHideParameters(nav);
 }
 
 function initLateralNav(courseData) {


### PR DESCRIPTION
Fix# 475 Preserve hide params on links

Before: https://main--www--cmegroup.aem.page/drafts/daiana/education/courses/course-share?hideHeader=y
After: https://issue-475-preserveHideParamsOnLinks--www--cmegroup.aem.page/drafts/daiana/education/courses/course-share?hideHeader=y

Add util to pull hide params off current page and include them on internal links in that page. Update courses to use the util on its dynamic content creation
