### PR TITLE
Issue 416 310 external links

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -307,7 +307,7 @@ export function buildFragmentBlocks(main) {
 export function decorateExternalLinks(main) {
   const linkConfig = {
     domain: 'cmegroup.com',
-    subdomains: ['events'],
+    subdomains: [],
   };
 
   const domainRegex = new RegExp(`^https?:\\/\\/([^/]+\\.)?${linkConfig.domain.replace('.', '\\.')}(\\/|$)`);

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -305,16 +305,30 @@ export function buildFragmentBlocks(main) {
  * @param {Element} main The main element
  */
 export function decorateExternalLinks(main) {
+  const linkConfig = {
+    domain: 'cmegroup.com',
+    subdomains: ['events'],
+  };
+
+  const domainRegex = new RegExp(`^https?:\\/\\/([^/]+\\.)?${linkConfig.domain.replace('.', '\\.')}(\\/|$)`);
+
   main.querySelectorAll('a').forEach((a) => {
     const href = a.getAttribute('href');
     if (href) {
       const extension = href.split('.').pop().trim();
       const isExternal = !href.startsWith('/') && !href.startsWith('#');
       const isPDF = extension === 'pdf';
-      const isCMEGroup = href.includes('cmegroup.com');
+      const isCMEGroup = domainRegex.test(href);
       const hasLinkOverride = a.querySelector('code') !== null;
 
-      if (isPDF || (isExternal && !isCMEGroup) || (isCMEGroup && hasLinkOverride)) {
+      const isConfiguredPage = linkConfig.subdomains.some((subdomain) => href.startsWith(`https://${subdomain}.${linkConfig.domain}`));
+
+      if (
+        isPDF
+        || (isExternal && !isCMEGroup)
+        || (isCMEGroup && hasLinkOverride)
+        || isConfiguredPage
+      ) {
         a.setAttribute('target', '_blank');
       }
     }

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -460,7 +460,7 @@ a:visited code {
   font-size: inherit;
 }
 
-a[target='_blank']::after {
+a:not(.button)[target='_blank']::after {
     font-family: var(--cme-group-icons);
     content: var(--icon-positive);
     color: var(--blue4);


### PR DESCRIPTION
remove subdomain validation in external link

Fix #310

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education/2025/commodity-index-trading-webinar-old
- After: https://issue-416-310-external-links--www--cmegroup.aem.live/education/2025/commodity-index-trading-webinar-old
