### PR TITLE
add author tags to article tags in tag cloud component

### DIFF
--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -263,7 +263,14 @@ async function getArticleRelatedMetadata() {
  * @returns {Object} Object containing article metadata
  */
 async function getPageTags() {
-  const metadataTags = getMetadata('article:tag');
+  let metadataTags = getMetadata('article:tag');
+  const authorTags = getMetadata('author');
+  if (authorTags) {
+    const metadataArray = metadataTags.split(',').map((tag) => tag.trim());
+    const authorArray = authorTags.split(',').map((tag) => tag.trim());
+    const allTagsSet = new Set([...metadataArray, ...authorArray]);
+    metadataTags = [...allTagsSet].join(', ');
+  }
   if (!metadataTags || metadataTags.trim() === '') {
     return [];
   }


### PR DESCRIPTION
add author tags to article tags in tag cloud component

Fix #534

Test URLs:
- Before: https://main--www--cmegroup.aem.live/drafts/ramiro/10-reasons-to-consider-managed-futures
- After: https://article-authors-tag--www--cmegroup.aem.live/drafts/ramiro/10-reasons-to-consider-managed-futures
