### PR TITLE
Add fragments to lesson and standalone template

### DIFF
--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -4,6 +4,9 @@ import {
   getMetadata,
   toCamelCase,
   toClassName,
+  buildBlock,
+  decorateBlock,
+  loadBlock,
 } from './aem.js';
 import ffetch from './ffetch.js';
 import {
@@ -741,6 +744,21 @@ function showTooltip(parent, content, hideAfter) {
   }
 }
 
+/**
+ * Appends a fragment block to the main element
+ * @param {string} fragmentUrl - The fragment URL to load
+ */
+async function addFragmentBlock(fragmentUrl) {
+  const main = document.querySelector('main');
+  if (!main) return;
+
+  const fragmentLink = createElement('a', { href: fragmentUrl }, fragmentUrl);
+  const fragmentBlock = buildBlock('fragment', [[fragmentLink]]);
+  main.appendChild(fragmentBlock);
+  decorateBlock(fragmentBlock);
+  await loadBlock(fragmentBlock);
+}
+
 export {
   loadScript,
   createElement,
@@ -767,4 +785,5 @@ export {
   getCountryCode,
   preserveHideParameters,
   showTooltip,
+  addFragmentBlock,
 };

--- a/aemedge/templates/lesson-standalone/lesson-standalone.js
+++ b/aemedge/templates/lesson-standalone/lesson-standalone.js
@@ -3,7 +3,9 @@ import { authentication } from '../../scripts/modules/Authentication.js';
 import { store } from '../../scripts/store/store.js';
 import { courseDataChange } from '../../scripts/actions/course.js';
 import { quizAnswered } from '../../scripts/actions/quiz.js';
-import { isFeatureToggled } from '../../scripts/utils.js';
+import { isFeatureToggled, addFragmentBlock } from '../../scripts/utils.js';
+
+const FRAGMENT_URL = '/fragments/courses-lessons/extend-your-learning';
 
 export default function lessonStandaloneTemplate() {
   const { authenticationData } = authentication;
@@ -13,6 +15,7 @@ export default function lessonStandaloneTemplate() {
     }
     const courseData = await getCourseData();
     await createCourseBaseTemplate(courseData);
+    await addFragmentBlock(FRAGMENT_URL);
     if (!courseData.started) {
       //  start lesson
       await updateLessonStatus(false);

--- a/aemedge/templates/lesson/lesson.js
+++ b/aemedge/templates/lesson/lesson.js
@@ -2,12 +2,15 @@ import {
   createCourseBaseTemplate, getCourseData, updateLessonStatus, getCurrentLesson,
 } from '../../scripts/course/course.js';
 import { addCourseCertificate } from '../../scripts/course/certificate.js';
-import { createElement, i18n, isFeatureToggled } from '../../scripts/utils.js';
+import {
+  createElement, i18n, isFeatureToggled, addFragmentBlock,
+} from '../../scripts/utils.js';
 import { authentication } from '../../scripts/modules/Authentication.js';
 import { store } from '../../scripts/store/store.js';
 import { courseDataChange } from '../../scripts/actions/course.js';
 import { quizAnswered } from '../../scripts/actions/quiz.js';
-import { buildBlock, decorateBlock, loadBlock } from '../../scripts/aem.js';
+
+const FRAGMENT_URL = '/fragments/courses-lessons/extend-your-learning';
 
 function flattenLessons(courseData) {
   const lessons = courseData.lessons || [];
@@ -104,18 +107,6 @@ async function addLateralNavigation(prevHref, nextHref) {
   preserveHideParameters(nav);
 }
 
-async function appendFragmentBlock() {
-  const main = document.querySelector('main');
-  if (!main) return;
-
-  const fragmentUrl = '/fragments/courses-lessons/extend-your-learning';
-  const fragmentLink = createElement('a', { href: fragmentUrl }, fragmentUrl);
-  const fragmentBlock = buildBlock('fragment', [[fragmentLink]]);
-  main.appendChild(fragmentBlock);
-  decorateBlock(fragmentBlock);
-  await loadBlock(fragmentBlock);
-}
-
 async function initLateralNav(courseData) {
   if (isFeatureToggled('hideCourseNav', 'y', true)) {
     return;
@@ -124,7 +115,7 @@ async function initLateralNav(courseData) {
   const flatLessons = flattenLessons(courseData);
   const { prevHref, nextHref } = findNavigationLinks(currentPath, flatLessons);
   await addLateralNavigation(prevHref, nextHref);
-  await appendFragmentBlock();
+  await addFragmentBlock(FRAGMENT_URL);
 }
 
 export default async function lessonTemplate() {


### PR DESCRIPTION
- Placing the fragment on template level for both lesson and standalone-lesson to cover for #503 
- added utils function to addFragment blocks

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #503 

Test URLs:
- After: https://lesson-template--www--cmegroup.aem.live/education/courses/pork-cutout-futures-product-overview
- After: https://lesson-template--www--cmegroup.aem.live/education/courses/options-on-futures-for-equity-traders/trading-options-on-futures-using-strategies-you-already-know
