### PR TITLE
Author line fragmentation  | use "and" before last author in article byline

### DIFF
--- a/aemedge/templates/article/article.js
+++ b/aemedge/templates/article/article.js
@@ -176,7 +176,7 @@ function renderAuthors(authorsData, container, byLabel) {
     return author.title;
   });
 
-  // Format authors with proper "and" conjunction
+  // Format authors with proper "and" conjunction.
   let authorsString;
   if (authorList.length === 1) {
     [authorsString] = authorList;

--- a/aemedge/templates/article/article.js
+++ b/aemedge/templates/article/article.js
@@ -176,16 +176,9 @@ function renderAuthors(authorsData, container, byLabel) {
     return author.title;
   });
 
-  // Format authors with proper "and" conjunction.
-  let authorsString;
-  if (authorList.length === 1) {
-    [authorsString] = authorList;
-  } else if (authorList.length === 2) {
-    authorsString = `${authorList[0]} and ${authorList[1]}`;
-  } else {
-    const lastAuthor = authorList.pop();
-    authorsString = `${authorList.join(', ')} and ${lastAuthor}`;
-  }
+  // Format authors with proper conjunction using browser's Intl.ListFormat
+  const locale = getMetadata('locale') || 'en';
+  const authorsString = new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' }).format(authorList);
 
   container.innerHTML = `${byLabel} ${authorsString}`;
 }

--- a/aemedge/templates/article/article.js
+++ b/aemedge/templates/article/article.js
@@ -175,7 +175,18 @@ function renderAuthors(authorsData, container, byLabel) {
     }
     return author.title;
   });
-  const authorsString = authorList.join(', ');
+
+  // Format authors with proper "and" conjunction
+  let authorsString;
+  if (authorList.length === 1) {
+    [authorsString] = authorList;
+  } else if (authorList.length === 2) {
+    authorsString = `${authorList[0]} and ${authorList[1]}`;
+  } else {
+    const lastAuthor = authorList.pop();
+    authorsString = `${authorList.join(', ')} and ${lastAuthor}`;
+  }
+
   container.innerHTML = `${byLabel} ${authorsString}`;
 }
 


### PR DESCRIPTION
Fix #596

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education/articles-and-reports/wti-and-the-changing-dynamics-of-global-crude-oil
- After: https://issue596-authorbyline--www--cmegroup.aem.live/education/articles-and-reports/wti-and-the-changing-dynamics-of-global-crude-oil
- After: https://issue596-authorbyline--www--cmegroup.aem.live/education/articles-and-reports/geo-futures-a-natural-solution
