### PR TITLE
fix: render tags in tag cloud only if title exists

### DIFF
--- a/aemedge/blocks/tags-cloud/tags-cloud.js
+++ b/aemedge/blocks/tags-cloud/tags-cloud.js
@@ -78,8 +78,11 @@ async function buildTagList(block, listPage) {
       class: 'btn-tag-filter',
       href: `${listPage || defaultUrl}#filters=${name}`,
     });
-    button.textContent = title;
-    block.append(button);
+
+    if (title) {
+      button.textContent = title;
+      block.append(button);
+    }
   });
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #611 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/education/articles-and-reports/agriculture-cash-settlement-vs-physical-delivery
- After: https://tag-cloud-fix--www--cmegroup.aem.page/education/articles-and-reports/agriculture-cash-settlement-vs-physical-delivery
