### PR TITLE
Issue-639: Navbar takes some time to load and be displayed

### DIFF
--- a/aemedge/blocks/cards/cards-article-card-list.css
+++ b/aemedge/blocks/cards/cards-article-card-list.css
@@ -1,6 +1,10 @@
 .cards {
   &.article {
     &.card-list {
+      &:has(.spinner-cards) {
+        height: 25rem;
+      }
+      
       & div > ul {
         grid-template-columns: repeat(auto-fit, minmax(8.375rem, 1fr));
       }

--- a/aemedge/blocks/cards/cards-article-list.css
+++ b/aemedge/blocks/cards/cards-article-list.css
@@ -1,6 +1,10 @@
 .cards {
   &.article {
     &.list {
+      &:has(.spinner-cards) {
+        height: 28.75rem;
+      }
+
       & div > ul {
         grid: none;
         grid-gap: 0;

--- a/aemedge/blocks/cards/cards-article-thumbnail-medium.css
+++ b/aemedge/blocks/cards/cards-article-thumbnail-medium.css
@@ -1,6 +1,10 @@
 .cards {
   &.article {
     &.thumbnail-medium  {
+      &:has(.spinner-cards) {
+        height: 12.5rem;
+      }
+
       & ul {
         display: flex;
         flex-wrap: wrap;

--- a/aemedge/blocks/cards/cards-course.css
+++ b/aemedge/blocks/cards/cards-course.css
@@ -3,6 +3,10 @@
     min-height: 20.875rem !important;
 }
 
+.cards.course:has(.spinner-cards) {
+    min-height: 20.875rem;
+}
+
 .cards.course ul {
     grid-template-columns: repeat(4, 1fr);
 }

--- a/aemedge/blocks/cards/cards-upcoming-events.css
+++ b/aemedge/blocks/cards/cards-upcoming-events.css
@@ -1,3 +1,7 @@
+.cards.upcoming-events:has(.spinner-cards) {
+  height: 7.5rem
+}
+
 .cards.upcoming-events ul .glider-track {
     column-gap: 1.1875rem;
 }

--- a/aemedge/blocks/hero/hero-base.css
+++ b/aemedge/blocks/hero/hero-base.css
@@ -19,6 +19,7 @@
     inset: 0;
     object-fit: cover;
     box-sizing: border-box;
+    height: 100% !important;
   }
 
   & img {

--- a/aemedge/blocks/hero/hero-landing.css
+++ b/aemedge/blocks/hero/hero-landing.css
@@ -57,10 +57,6 @@
         }
       }
     }
-
-    &:has(picture) {
-      display: none;
-    }
   }
 
   &.small {

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -110,9 +110,6 @@ async function decorateEconodayEventPageHero(block) {
  * Generic hero section
  */
 function decorateGenericHero(block) {
-  const image = block.querySelector('picture img');
-  block.style.backgroundImage = `url('${image.src}')`;
-  image.remove();
   const contentDiv = block.children.item(0);
   contentDiv.classList.add('container');
 }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -5,14 +5,14 @@ import {
   decorateBlock,
   decorateTemplateAndTheme,
   waitForFirstImage,
-  loadSection,
-  loadSections,
   loadCSS,
   toCamelCase,
   toClassName,
   getMetadata,
   buildBlock,
   updateTitleAndMetaTags,
+  loadSection,
+  sampleRUM,
 } from './aem.js';
 import initFloatingElements from './alerts/alerts.js';
 import { authentication, dataLayer } from './modules/index.js';
@@ -765,6 +765,26 @@ async function loadEager(doc) {
 }
 
 /**
+ * Loads all sections.
+ * @param {Element} element The parent element of sections to load
+ */
+async function loadSections(element) {
+  return new Promise((resolve) => {
+    (async () => {
+      const sections = [...element.querySelectorAll('div.section')];
+      for (let i = 0; i < sections.length; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await loadSection(sections[i]);
+        if (i === 0 && sampleRUM.enhance) {
+          sampleRUM.enhance();
+        }
+      }
+      resolve();
+    })();
+  });
+}
+
+/**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
  */
@@ -774,13 +794,26 @@ async function loadLazy(doc) {
   autolinkModals(doc);
 
   const main = doc.querySelector('main');
-  await loadSections(main);
-  initParallaxSections(main);
+  loadSections(main).then(() => {
+    initParallaxSections(main);
+    const { hash } = window.location;
+    const element = hash ? doc.getElementById(hash.substring(1)) : false;
+    if (hash && element) element.scrollIntoView();
 
-  const { hash } = window.location;
-  const element = hash ? doc.getElementById(hash.substring(1)) : false;
-  if (hash && element) element.scrollIntoView();
+    if (!isFeatureToggled('hideFooter')) {
+      loadFooter(doc.querySelector('footer')).then((footer) => {
+        enhanceIconAccessibility(footer);
+      });
+    }
 
+    dynamicBlocks(main);
+    loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
+    loadFonts();
+    window.CookieUtil = CookieUtil;
+    window.LocalStorageUtil = LocalStorageUtil;
+    window.SessionStorageUtil = SessionStorageUtil;
+    authentication.handleLoad();
+  });
   // Add feature toggle checks for header and footer
   if (!isFeatureToggled('hideHeader')) {
     loadHeader(doc.querySelector('header')).then((header) => {
@@ -791,19 +824,6 @@ async function loadLazy(doc) {
     // Add class to body when header is hidden to remove top padding
     doc.body.classList.add('header-hidden');
   }
-  if (!isFeatureToggled('hideFooter')) {
-    loadFooter(doc.querySelector('footer')).then((footer) => {
-      enhanceIconAccessibility(footer);
-    });
-  }
-
-  dynamicBlocks(main);
-  loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
-  loadFonts();
-  window.CookieUtil = CookieUtil;
-  window.LocalStorageUtil = LocalStorageUtil;
-  window.SessionStorageUtil = SessionStorageUtil;
-  authentication.handleLoad();
 }
 
 /**


### PR DESCRIPTION
Improves the performance of the education homepage to avoid page stay blank for a few seconds in the initial load and prevent navbar takes several seconds to appear.
Fixes education mobile score (it's about 75).
Add default height to cards dynamic variations when the data is loading to get a better CLS.

Fix #639 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/education
- After: https://issue-639-navbar-blank--www--cmegroup.aem.page/education
