### PR TITLE
Handle standalone images in convertImagesToLinks

### DIFF
--- a/tools/importer/importer.js
+++ b/tools/importer/importer.js
@@ -1229,6 +1229,7 @@ const tableBlock = (document) => {
 };
 
 const convertImagesToLinks = (document) => {
+  // Handle .component.image elements
   const images = document.querySelectorAll('.component.image');
 
   images.forEach((image) => {
@@ -1261,6 +1262,25 @@ const convertImagesToLinks = (document) => {
       }
 
       image.replaceWith(div);
+    }
+  });
+
+  // Handle standalone images in text components
+  const standaloneImages = document.querySelectorAll('.component.text img');
+  standaloneImages.forEach((img) => {
+    // Skip if image is already inside an anchor (clickable image)
+    if (img.closest('a')) return;
+
+    let imgSrc = img.getAttribute('src');
+    if (imgSrc?.startsWith('/')) {
+      imgSrc = `${DOMAIN}${imgSrc}`;
+    }
+
+    if (imgSrc) {
+      const anchor = document.createElement('a');
+      anchor.href = imgSrc;
+      anchor.textContent = imgSrc;
+      img.replaceWith(anchor);
     }
   });
 };


### PR DESCRIPTION
Handle standalone images in convertImagesToLinks via importer

Fix #648 

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education/ahl-founders-their-past-present-future
- After: https://issue-standaloneimages--www--cmegroup.aem.live/education/ahl-founders-their-past-present-future
