### PR TITLE
issue-662-sharethis overlapped by the navbar

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -1721,7 +1721,7 @@ body.loading::before {
 }
 
 #st-2.st-right {
-  z-index: 1 !important;
+  z-index: 100000 !important;
 }
 
 /* general classes */


### PR DESCRIPTION
Fix [662](https://github.com/aemsites/cmegroup/issues/662)

Test URLs:
- Before: https://main--www--cmegroup.aem.page/drafts/daiana/education/courses/course-share
- After: https://issue-662-sharethis--www--cmegroup.aem.page/drafts/daiana/education/courses/course-share