### PR TITLE
fix(cuwst-439): force www continue to hit beta svcs

### DIFF
--- a/aemedge/scripts/utils/env.js
+++ b/aemedge/scripts/utils/env.js
@@ -8,5 +8,20 @@ export function getEnvType() {
 }
 
 export function urlByEnvType() {
-  return `https://${getEnv()}.cmegroup.com`;
+  // Once we deploy new services in prod we will have to make www hit prod, not beta
+  const env = getEnv();
+  let subdom;
+  switch (env) {
+    case 'preview':
+      subdom = 'preview';
+      break;
+    case 'beta':
+    case 'www':
+      subdom = 'beta';
+      break;
+    default:
+      subdom = 'www';
+      break;
+  }
+  return `https://${subdom}.cmegroup.com`;
 }


### PR DESCRIPTION
Force www content to continue hitting beta services.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www--cmegroup.aem.live/
- After: https://login-updates-fix--www--cmegroup.aem.live/
