### PR TITLE
fix(cuwst-439): send correct target url based on the domain

### DIFF
--- a/aemedge/scripts/modules/Authentication.js
+++ b/aemedge/scripts/modules/Authentication.js
@@ -1,5 +1,10 @@
 // import store from 'store';
-import { URIUtil, openHiddenIframe, getEnvType } from '../utils/index.js';
+import {
+  URIUtil,
+  openHiddenIframe,
+  getEnvType,
+  isCMEEnv,
+} from '../utils/index.js';
 import { store } from '../store/store.js';
 import { authLogin, authLogout } from '../actions/auth.js';
 import {
@@ -48,8 +53,8 @@ export class Authentication {
   }
 
   initialize() {
-    this.loginProcessUrl = '/login-confirmed';
-    this.loginUrl = `http://auth${getEnvType() !== 'prod' ? 'nr' : ''}.cmegroup.com/idp/startSSO.ping?PartnerSpId=https://main--preview-www--cmegroup.aem.page&TARGET=${window.location.origin}/login-confirmed`;
+    const loginProcessUrl = `${window.location.origin}/login-confirmed${isCMEEnv() ? '.html' : ''}`;
+    this.loginUrl = `http://auth${getEnvType() !== 'prod' ? 'nr' : ''}.cmegroup.com/idp/startSSO.ping?PartnerSpId=https://main--preview-www--cmegroup.aem.page&TARGET=${loginProcessUrl}`;
     this.registerUrl = `https://login${getEnvType() !== 'prod' ? 'nr' : ''}.cmegroup.com/sso/register/`;
     this.logoutProfileUrl = `https://myprofile${getEnvType() !== 'prod' ? 'nr' : ''}.cmegroup.com/admin/ssoflo`;
     this.isMobileLogin = false;
@@ -465,10 +470,6 @@ export class Authentication {
       company: fixEncode(data.company),
       companyType: fixEncode(data.companyType),
     };
-  }
-
-  inLoginProcess() {
-    return this.loginProcessUrl.indexOf(window.location.pathname) > -1;
   }
 }
 

--- a/aemedge/scripts/utils/env.js
+++ b/aemedge/scripts/utils/env.js
@@ -3,6 +3,11 @@ export function getEnv() {
   return hostname.match(/(preview|beta|www)(-www|\.cmegroup)?/)?.[1] ?? 'www';
 }
 
+export function isCMEEnv() {
+  const { location: { hostname } } = window;
+  return !!hostname.match(/\.cmegroup\.com/)?.at(0);
+}
+
 export function getEnvType() {
   return getEnv() === 'www' ? 'prod' : 'stage';
 }


### PR DESCRIPTION
Send correct target login process url to SAML based on the domain on which the user is logging in.

Test URLs:
- Before: https://main--www--cmegroup.aem.live/
- After: https://login-updates--www--cmegroup.aem.live/
