### PR TITLE
fix: handle localhost URLs and extension-less relative paths in link

### DIFF
--- a/tools/importer/importer.js
+++ b/tools/importer/importer.js
@@ -1453,7 +1453,7 @@ const correctLinks = (document, meta) => {
           continue;
         }
 
-        const completeLink = new URL(link.href);
+        const completeLink = new URL(link.href, 'https://www.cmegroup.com');
         const { pathname } = completeLink;
         const oldHref = link.href;
 
@@ -1509,6 +1509,22 @@ const correctLinks = (document, meta) => {
                 link.textContent = completeLink.toString();
               }
               link.href = completeLink.toString();
+            }
+          }
+        } else {
+          const isLocalhost = completeLink.hostname === 'localhost';
+          const isRelativePath = link.href.startsWith('/');
+
+          if (isRelativePath || isLocalhost) {
+            // Handle relative paths without extensions
+            if (pathname.startsWith('/education/')) {
+              link.href = `${EDS_DOMAIN}${pathname}`;
+            } else {
+              link.href = `${DOMAIN}${pathname}`;
+            }
+
+            if (link.textContent === oldHref) {
+              link.textContent = link.href;
             }
           }
         }


### PR DESCRIPTION
fix: handle localhost URLs and extension-less relative paths in link on importer.js

See thread for details : https://adobe-dx-support.slack.com/archives/C06PK80B5A5/p1757368452155699?thread_ts=1757364417.669809&cid=C06PK80B5A5