### PR TITLE
Issue 678 search block issue

### DIFF
--- a/aemedge/blocks/search/search-results/search-results.js
+++ b/aemedge/blocks/search/search-results/search-results.js
@@ -15,11 +15,11 @@ function showSpinner(container) {
   container.appendChild(spinner);
 }
 
-const buildSearchRequest = () => {
+function buildSearchRequest(filterId) {
   const request = {
     basePaths: searchConfig.basePaths,
     page: searchConfig.pagination?.currentPage || 1,
-    limit: searchConfig.pagination?.size || 10,
+    limit: filterId ? 0 : searchConfig.pagination?.size || 10,
     fullText: searchConfig.searchInput || '',
     languages: ['en'], // currently hardcoding languages
     getFacets: searchConfig.getFacets,
@@ -32,10 +32,12 @@ const buildSearchRequest = () => {
   const mp = {};
   searchConfig.appliedFilters.forEach((filter) => {
     const value = filter.value.endsWith('--star') ? filter.value.replace('--star', '') : filter.value;
-    if (mp[filter.filterId]) {
-      mp[filter.filterId].push(value);
-    } else {
-      mp[filter.filterId] = [value];
+    if (!filterId || filterId !== filter.filterId) {
+      if (mp[filter.filterId]) {
+        mp[filter.filterId].push(value);
+      } else {
+        mp[filter.filterId] = [value];
+      }
     }
   });
 
@@ -58,12 +60,47 @@ const buildSearchRequest = () => {
   }
 
   return buildIndexFilter(request);
-};
+}
+
+async function executeSearch() {
+  const apiReq = buildSearchRequest();
+  if (!searchConfig.getFacets || searchConfig.appliedFilters.length === 0) {
+    const res = await getIndexedContent(apiReq);
+    return res;
+  }
+  const filters = [...new Set(searchConfig.appliedFilters.map((item) => item.filterId))];
+  const reqs = filters.map((filter) => buildSearchRequest(filter));
+  const results = await Promise.all([apiReq, ...reqs].map(getIndexedContent));
+  const res = results.shift();
+  filters.forEach((filterId, index) => {
+    const filter = document.getElementById(filterId);
+    if (filter) {
+      const localres = results[index];
+      if (localres.facets) {
+        filter.querySelectorAll('.dropdown-option, .checkbox-option').forEach((element) => {
+          const facetValue = element.querySelector('input').value;
+          const matchingFacet = localres.facets.find((f) => f.tag === facetValue);
+          if (matchingFacet) {
+            if (!res.facets) {
+              res.facets = [];
+            }
+            const resFacet = res.facets.find((f) => f.tag === facetValue);
+            if (resFacet) {
+              resFacet.count = matchingFacet.count;
+            } else {
+              res.facets.push(matchingFacet);
+            }
+          }
+        });
+      }
+    }
+  });
+  return res;
+}
 
 const searchResults = async () => {
-  const apiReq = buildSearchRequest();
   showSpinner(document.querySelector('.results-wrapper'));
-  const results = await getIndexedContent(apiReq);
+  const results = await executeSearch();
 
   if (results && Object.keys(results).length > 0) {
     // Update pagination info from response

--- a/aemedge/blocks/search/search-results/search-results.js
+++ b/aemedge/blocks/search/search-results/search-results.js
@@ -214,7 +214,12 @@ async function filterAndRender(results) {
   }
 }
 
-const searchResults = debounce(searchResultsInternal, 500);
+const searchResultsDebounced = debounce(searchResultsInternal, 500);
+
+const searchResults = () => {
+  showSpinner(document.querySelector('.results-wrapper'));
+  searchResultsDebounced();
+};
 
 export {
   searchResults,

--- a/aemedge/blocks/search/search-results/search-results.js
+++ b/aemedge/blocks/search/search-results/search-results.js
@@ -4,7 +4,7 @@ import {
 import searchConfig from '../search-config.js';
 import { updateFilteringByUI } from '../filter-bullets/filter-bullets.js';
 import { getCards } from './cards-template.js';
-import { i18n, setupDayjsLibs } from '../../../scripts/utils.js';
+import { i18n, setupDayjsLibs, debounce } from '../../../scripts/utils.js';
 import { clearAllFilters } from '../search-utils.js';
 import { buildIndexFilter, getIndexedContent } from '../../../scripts/indexing.js';
 import renderPagination from './pagination.js';
@@ -98,9 +98,16 @@ async function executeSearch() {
   return res;
 }
 
-const searchResults = async () => {
+let lastSearch = 0;
+
+const searchResultsInternal = async () => {
+  lastSearch += 1;
+  const currentSearch = lastSearch;
   showSpinner(document.querySelector('.results-wrapper'));
   const results = await executeSearch();
+  if (currentSearch < lastSearch) {
+    return;
+  }
 
   if (results && Object.keys(results).length > 0) {
     // Update pagination info from response
@@ -181,7 +188,7 @@ async function filterAndRender(results) {
     reset.onclick = async (e) => {
       e.preventDefault();
       clearAllFilters();
-      await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResults);
+      await updateFilteringByUI(document.querySelector('.filter-bullets'), searchResultsInternal);
     };
     resultsWrapper.appendChild(noResultsDiv);
     return;
@@ -202,10 +209,12 @@ async function filterAndRender(results) {
   // Render pagination if enabled
   if (searchConfig.pagination?.show) {
     await renderPagination(resultsWrapper, async () => {
-      await searchResults();
+      await searchResultsInternal();
     });
   }
 }
+
+const searchResults = debounce(searchResultsInternal, 500);
 
 export {
   searchResults,

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -772,6 +772,14 @@ async function addFragmentBlock(fragmentUrl) {
   await loadBlock(fragmentBlock);
 }
 
+function debounce(fn, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(this, args), delay);
+  };
+}
+
 export {
   loadScript,
   createElement,
@@ -801,4 +809,5 @@ export {
   showAuthToast,
   addFragmentBlock,
   getLanguageLabel,
+  debounce,
 };


### PR DESCRIPTION
Fixes the issue in filter items count (facets count) by doing some improvements:

1. Perform an extra call to the API for each filter with selected values, but excluding the values on that filter to get the full count of each.
2. Include debounce function with 500ms of delay on filters selection to avoid excessive API calls.
3. Track the last call to search function to avoid out of sync updates.

Fix #678 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/drafts/nestor/browse-all
- After: https://issue-678-search-block-issue--www--cmegroup.aem.page/drafts/nestor/browse-all
