### PR TITLE
case insensitive for external image regex

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -304,7 +304,7 @@ function isExternalImage(element) {
   // if the element is not an anchor, it's not an external image
   if (element.tagName !== 'A') return false;
   // IMPLICIT via CME Group Delivery URLs or OOTB DMOpenAPI Delivery URLs
-  return /\.(jpe?g|png|gif|webp|bmp|svg)(\?.*)?$/.test(element.getAttribute('href'));
+  return /\.(jpe?g|png|gif|webp|bmp|svg)(\?.*)?$/i.test(element.getAttribute('href'));
 }
 
 /**


### PR DESCRIPTION
case insensitive for external image regex

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education/articles-and-reports/platinum-industrial-demand
- After: https://externalimage--www--cmegroup.aem.live/education/articles-and-reports/platinum-industrial-demand
