### PR TITLE
Issue-779: Cards block, news pages in article variations

### DIFF
--- a/aemedge/blocks/cards/cards.js
+++ b/aemedge/blocks/cards/cards.js
@@ -22,6 +22,7 @@ import {
   mapLegacyArticleData,
   isLegacyContent,
   legacyOpenMarketsTemplates,
+  legacyNewsTemplates,
 } from '../../scripts/legacyContentMapping.js';
 import { wrapImgsInLinks } from '../../scripts/utils/dom.js';
 
@@ -492,7 +493,16 @@ export async function createDynamicCards(block) {
   } else if (block.classList.contains('article')) {
     const articleTypeConfig = getArticleTypeConfig(block);
     const indexFilter = buildIndexFilter(config);
-    indexFilter.templates = ['article', ...legacyArticleTemplates];
+    if (!indexFilter.templates || indexFilter.templates.length === 0) {
+      indexFilter.templates = ['article', ...legacyArticleTemplates];
+    } else {
+      if (indexFilter.templates.includes('article')) {
+        indexFilter.templates = [...indexFilter.templates, ...legacyArticleTemplates];
+      }
+      if (indexFilter.templates.includes('news')) {
+        indexFilter.templates = [...indexFilter.templates, ...legacyNewsTemplates];
+      }
+    }
     if (!indexFilter.basePaths || indexFilter.basePaths.length === 0) {
       indexFilter.basePaths = ['/education', '/content/cmegroup/en'];
     }

--- a/aemedge/scripts/legacyContentMapping.js
+++ b/aemedge/scripts/legacyContentMapping.js
@@ -126,6 +126,10 @@ const legacyOpenMarketsTemplates = [
   '/conf/openmarkets/settings/wcm/templates/openmarkets-video-template',
 ];
 
+const legacyNewsTemplates = [
+  '/conf/cmegroupaem/settings/wcm/templates/cme-group-press-release-template',
+];
+
 export {
   legacyArticleTemplates,
   mapLegacyArticleData,
@@ -133,4 +137,5 @@ export {
   legacyEducationTemplates,
   normalizeLegacyPath,
   legacyOpenMarketsTemplates,
+  legacyNewsTemplates,
 };


### PR DESCRIPTION
Added the configuration "templates" to the articles cards variation to allow the authors to pull news, articles or both

Fix #779 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/drafts/nestor/cards
- After: https://issue-779-cards-block-news--www--cmegroup.aem.page/drafts/nestor/cards
