### PR TITLE
Issue for navigate lessons with html extensions

### DIFF
--- a/aemedge/blocks/dynamic/course-nav/course-nav.js
+++ b/aemedge/blocks/dynamic/course-nav/course-nav.js
@@ -4,7 +4,6 @@ import {
   i18n,
   preserveHideParameters,
 } from '../../../scripts/utils.js';
-import { URIUtil } from '../../../scripts/utils/index.js';
 import { store } from '../../../scripts/store/store.js';
 
 function getTotalLessonsCount(courseData) {
@@ -246,7 +245,7 @@ function renderOrderedContent(courseData, currentPath, content) {
 
 async function buildCourseNav(main, courseData, prevCourseData) {
   await loadCSS(`${window.hlx.codeBasePath}/blocks/dynamic/course-nav/course-nav.css`);
-  const currentPath = new URIUtil().removeSelector(1).pathname();
+  const currentPath = window.location.pathname.replace(/\.html$/, '');
   const totalLessons = getTotalLessonsCount(courseData);
 
   let nav = main.querySelector('.course-nav');

--- a/aemedge/templates/lesson/lesson.js
+++ b/aemedge/templates/lesson/lesson.js
@@ -9,7 +9,7 @@ import { authentication } from '../../scripts/modules/Authentication.js';
 import { store } from '../../scripts/store/store.js';
 import { courseDataChange } from '../../scripts/actions/course.js';
 import { quizAnswered } from '../../scripts/actions/quiz.js';
-import { setTracking, URIUtil } from '../../scripts/utils/index.js';
+import { setTracking } from '../../scripts/utils/index.js';
 
 const FRAGMENT_URL = '/fragments/courses-lessons/extend-your-learning';
 
@@ -118,7 +118,7 @@ async function initLateralNav(courseData) {
   if (isFeatureToggled('hideCourseNav', 'y', true) || window.location.pathname.includes('.hideCourseNav.')) {
     return null;
   }
-  const currentPath = new URIUtil().removeSelector(1).pathname();
+  const currentPath = window.location.pathname.replace(/\.html$/, '');
   const flatLessons = flattenLessons(courseData);
   const { prevHref, nextHref } = findNavigationLinks(currentPath, flatLessons);
   await addLateralNavigation(prevHref, nextHref);


### PR DESCRIPTION
Course and lateral nav blocks: Issue for navigate lessons with html extensions

Test URLs:

Before: https://main--www--cmegroup.aem.page/education/courses/introduction-to-futures/definition-of-a-futures-contract
After: https://issue-lesson-extension--www--cmegroup.aem.page/education/courses/introduction-to-futures/definition-of-a-futures-contract