### PR TITLE
Issue-793: Fixing spacing between author bio, article header and disclaimer

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -962,9 +962,8 @@ main {
     padding-top: 6.25rem;
   }
 
-  & > .section:not(.divider-container, .hero-container) {
+  & > .section:not(.divider-container, .hero-container, .hero) {
     margin-bottom: 1.875rem;
-    padding: 1.875rem 0;
 
     &.text-1,
     &.text-2,
@@ -1165,6 +1164,7 @@ main {
 
     &.gray6-background {
       background-color: var(--gray6);
+      padding: 1.875rem 0;
     }
 
     &.not-full-width {


### PR DESCRIPTION
Fixed extra spacing in sections

Fix #793 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/education/articles-and-reports/treasury-cash-market-penetration-tcmp
- After: https://issue-793-section-spacing--www--cmegroup.aem.page/education/articles-and-reports/treasury-cash-market-penetration-tcmp
