### PR TITLE
Login url update to use new PartnerSpIds

### DIFF
--- a/aemedge/scripts/modules/Authentication.js
+++ b/aemedge/scripts/modules/Authentication.js
@@ -56,7 +56,7 @@ export class Authentication {
   initialize() {
     const loginProcessUrl = `${window.location.origin}/login-confirmed${isCMEEnv() ? '.html' : ''}`;
     // ToDo: the following urls must be updated before going live
-    this.loginUrl = `http://authnr.cmegroup.com/idp/startSSO.ping?PartnerSpId=https://main--preview-www--cmegroup.aem.page&TARGET=${loginProcessUrl}`;
+    this.loginUrl = `http://authnr.cmegroup.com/idp/startSSO.ping?PartnerSpId=${urlByEnvType()}&TARGET=${loginProcessUrl}`;
     this.registerUrl = 'https://loginnr.cmegroup.com/sso/register/';
     this.logoutProfileUrl = 'https://myprofilenr.cmegroup.com/admin/ssoflo';
     // this.loginUrl = `http://auth${getEnvType() !== 'prod' ? 'nr' : ''}.cmegroup.com/idp/startSSO.ping?PartnerSpId=https://main--preview-www--cmegroup.aem.page&TARGET=${loginProcessUrl}`;


### PR DESCRIPTION
The new PartnerSpId for beta environment has been set for SAML.

Test URLs:
- Before: https://main--www--cmegroup.aem.live/
- After: https://login-url-update--www--cmegroup.aem.live/
