### PR TITLE
CUEN-599 - Fix Images on Event List Calendar

### DIFF
--- a/aemedge/blocks/event-list/event-list.js
+++ b/aemedge/blocks/event-list/event-list.js
@@ -30,7 +30,7 @@ function createUpcomingEvent(content, timeZoneLabel) {
   const locationtag = createElement('div', { class: 'card-location' }, spanWebinar, location);
   const timeTag = createElement('div', { class: 'card-time' }, `${timeZoneLabel}: `, cdtDate.format('hh:mm a [CT]'));
   const cardBody = createElement('div', { class: 'card-body' }, dateTag, titletag, locationtag, timeTag);
-  const imagetag = createElement('img', { src: image || ogImage});
+  const imagetag = createElement('img', { src: image || ogImage });
   const cardImage = createElement('div', { class: 'card-image' }, imagetag);
   return createElement('a', { class: 'card', href: path }, cardImage, cardBody);
 }


### PR DESCRIPTION
Event list calendar is looking for og:image instead of image. Need to update the index call to look for image to display the event thumbnails. 

Fix # https://cmegroup.atlassian.net/browse/CUEN-599

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education/events
- After: https://cuen-599--www--cmegroup.aem.page/education/events
