### PR TITLE
Issue-838: Promo link issue - font color on citron background

### DIFF
--- a/aemedge/blocks/cards/cards-promo-link.css
+++ b/aemedge/blocks/cards/cards-promo-link.css
@@ -21,6 +21,13 @@
 
     &.citron-background {
         background-color: var(--citron);
+
+        & a {
+          & h3,
+          & p {
+              color: var(--black);
+          }
+        }
     }
 
     &.yellow-arrow .cards-body-container a::after {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #838 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/education
- After: https://issue-838-citron-promo-font--www--cmegroup.aem.page/education
