### PR TITLE
Oneclick subscription - thanks message is not visible when login insi…

### DIFF
--- a/aemedge/blocks/form/form.js
+++ b/aemedge/blocks/form/form.js
@@ -562,7 +562,7 @@ async function checkOneClickFormCookie(form, block) {
     window.CookieUtil?.remove('oneClickFormCookie');
     if (thanksMsg) {
       showAuthToast(
-        thanksMsg,
+        thanksMsg.cloneNode(true),
         'success',
         true,
       );


### PR DESCRIPTION
Oneclick subscription issue:  thanks message is not visible when login inside component

Test URLs:

Before: https://main--www--cmegroup.aem.live/education
After: https://issue-one-click-thanks-message--www--cmegroup.aem.live/education