### PR TITLE
Issue-949: Link bold in reverse section has wrong background color

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -460,17 +460,6 @@ p {
   }
 }
 
-/* stylelint-disable-next-line no-duplicate-selectors */
-.reverse {
-  & a[target="_blank"] {
-    background-image: linear-gradient(
-      90deg,
-      rgb(255 255 255 / 0%) 50%,
-      var(--blue5) 0%
-    );
-  }
-}
-
 /* p & span */
 p,
 span,


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #949 

Test URLs:
- Before: https://main--www--cmegroup.aem.page/education/navigating-uncleared-margin-rules
- After: https://issue-949-link-bold-reverse-section--www--cmegroup.aem.page/education/navigating-uncleared-margin-rules
