### PR TITLE
GA4 tracking for iframed pages

### DIFF
--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -9,6 +9,20 @@ function loadShareThis() {
   loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=644646a57ac381001a304496&product=sticky-share-buttons&source=platform');
 }
 
+async function trackIframedPage() {
+  const { self, top } = window;
+  if (self === top) {
+    return;
+  }
+  const { trackGA4Event } = await import('./gtm.js');
+  const {
+    location: { origin, href },
+  } = self;
+  trackGA4Event(origin, 'iframe_view', {
+    url: href,
+  });
+}
+
 async function loadOneTrust() {
   const ONETRUST_CONFIG = {
     stubScript: {
@@ -41,6 +55,7 @@ export default function loadPage() {
   }
 
   loadOneTrust();
+  trackIframedPage();
 }
 
 loadPage();

--- a/aemedge/scripts/gtm.js
+++ b/aemedge/scripts/gtm.js
@@ -40,3 +40,21 @@ export function setTracking(
     event, eventCategory, status, detail, value,
   });
 }
+
+export async function trackGA4Event(
+  origin,
+  eventName,
+  details = {},
+) {
+  try {
+    const params = new URLSearchParams({
+      event: eventName,
+      ...details,
+    });
+    const response = await fetch(`${origin}/ga-hit.html?${params.toString()}`);
+    if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log('Tracking error:', error);
+  }
+}


### PR DESCRIPTION
Execute GA4 tracking when pages are iframed on 3rd party sites.

CUWST-824

Test URLs:
- Before: https://main--www--cmegroup.aem.live/education
- After: https://iframes-to-ga4--www--cmegroup.aem.live/education
